### PR TITLE
Add node --inspect support for child processes

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -20,6 +20,12 @@ function Pool(script, options) {
   this.workers = [];  // queue with all workers
   this.tasks = [];    // queue with tasks awaiting execution
 
+  options = options || {};
+
+  this.forkArgs = options.forkArgs || [];
+  this.forkOpts = options.forkOpts || {};
+  this.debugPortStart = options.debugPortStart || 43210;
+
   // configuration
   if (options && 'maxWorkers' in options) {
     if (!isNumber(options.maxWorkers) || !isInteger(options.maxWorkers) || options.maxWorkers < 1) {
@@ -204,7 +210,11 @@ Pool.prototype._getWorker = function() {
 
   if (this.workers.length < this.maxWorkers) {
     // create a new worker
-    worker = new WorkerHandler(this.script);
+    worker = new WorkerHandler(this.script, {
+      forkArgs: this.forkArgs,
+      forkOpts: this.forkOpts,
+      debugPort: this.debugPortStart + this.workers.length
+    });
     this.workers.push(worker);
     return worker;
   }
@@ -274,10 +284,36 @@ Pool.prototype.stats = function () {
 Pool.prototype._ensureMinWorkers = function() {
   if (this.minWorkers) {
     for(var i = this.workers.length; i < this.minWorkers; i++) {
-      this.workers.push(new WorkerHandler(this.script));
+      this.workers.push(new WorkerHandler(this.script, {
+        forkArgs: this.forkArgs,
+        forkOpts: this.forkOpts,
+        debugPort: this.debugPortStart + i
+      }));
     }
   }
 };
+
+/**
+ * Ensure that the maxWorkers option is a positive integer
+ * @param {*} value
+ * @returns {boolean} returns true when value is a positive integer
+ */
+function validateMaxWorkers(maxWorkers) {
+  if (!isNumber(maxWorkers) || !isInteger(maxWorkers) || maxWorkers < 1) {
+    throw new TypeError('Option maxWorkers must be a positive integer number');
+  }
+}
+
+/**
+ * Ensure that the minWorkers option is a positive integer
+ * @param {*} value
+ * @returns {boolean} returns true when value is a positive integer
+ */
+function validateMinWorkers(minWorkers) {
+  if (!isNumber(minWorkers) || !isInteger(minWorkers) || minWorkers < 0) {
+    throw new TypeError('Option minWorkers must be a positive integer number');
+  }
+}
 
 /**
  * Test whether a variable is a number

--- a/lib/WorkerHandler.js
+++ b/lib/WorkerHandler.js
@@ -6,6 +6,10 @@ var environment = require('./environment');
 // used to prevent webpack from resolving requires on node libs
 var node = {require: require};
 
+var assign = environment.platform === 'node'
+  ? require('object-assign')
+  : null;
+
 // get the default worker script
 function getDefaultWorker() {
   if (environment.platform == 'browser') {
@@ -26,6 +30,34 @@ function getDefaultWorker() {
     return __dirname + '/worker.js';
   }
 }
+
+// add debug flags to child processes if the node inspector is active
+function resolveForkOptions(opts) {
+  opts = opts || {};
+
+  const execArgv = [];
+
+  const inspectorActive = process.execArgv
+    .indexOf('--inspect') !== -1;
+  const debugBrk = process.execArgv
+    .indexOf('--debug-brk') !== -1;
+
+  if (inspectorActive) {
+    execArgv.push('--inspect=' + opts.debugPort);
+
+    if (debugBrk) {
+      execArgv.push('--debug-brk');
+    }
+  }
+
+  return assign({}, opts, {
+    forkArgs: opts.forkArgs,
+    forkOpts: assign({}, opts.forkOpts, {
+      execArgv: (opts.forkOpts && opts.forkOpts.execArgv || [])
+        .concat(execArgv)
+    })
+  });
+};
 
 /**
  * Converts a serialized error to Error
@@ -50,8 +82,10 @@ function objectToError (obj) {
  *                          function run will be created.
  * @constructor
  */
-function WorkerHandler(script) {
+function WorkerHandler(script, options) {
   this.script = script || getDefaultWorker();
+
+  var forkOptions;
 
   if (environment.platform == 'browser') {
     // check whether Worker is supported by the browser
@@ -75,8 +109,14 @@ function WorkerHandler(script) {
   }
   else {
     // on node.js, create a child process
+    forkOptions = resolveForkOptions(options);
+
     // call node.require to prevent child_process to be required when loading with AMD
-    this.worker = node.require('child_process').fork(this.script);
+    this.worker = node.require('child_process').fork(
+      this.script,
+      forkOptions.forkArgs,
+      forkOptions.forkOpts
+    );
   }
 
   var me = this;

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "mocha": "^2.5.3",
     "uglify-js": "^2.6.4",
     "webpack": "^1.13.1"
+  },
+  "dependencies": {
+    "object-assign": "^4.1.1"
   }
 }


### PR DESCRIPTION
Also adds support for passing `args` and `opts` to `fork()`.

Tested with `--inspect` and `--debug-brk`, all seems well.

Resolves #2 and #19 