### PR TITLE
Fixed debug issue - look for '--inspect' within argument strings, instead of exact match

### DIFF
--- a/lib/WorkerHandler.js
+++ b/lib/WorkerHandler.js
@@ -34,8 +34,10 @@ function resolveForkOptions(opts) {
 
   const execArgv = [];
 
-  const inspectorActive = process.execArgv
-    .indexOf('--inspect') !== -1;
+  var inspectorActive = false;
+  process.execArgv.some(function(value) {
+    if (value.indexOf('--inspect') !== -1) { inspectorActive = true; return true; }
+  });
   const debugBrk = process.execArgv
     .indexOf('--debug-brk') !== -1;
 


### PR DESCRIPTION
Recent versions of node allow extended forms of the --inspect parameter, such as --inspect-brk or --inspect=<port>. (See https://nodejs.org/en/docs/inspector/) This change will enable the inspector on a  worker process if any parameter contains '--inspect', rather than requiring an exact match. I needed to add this in order to be able to use breakpoints in the worker process in WebStorm.