### PR TITLE
Fixed bug where tasks that are cancelled in a Pool's queue causes following tasks to not run

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -99,7 +99,7 @@ Pool.prototype.exec = function (method, params) {
 
     // replace the timeout method of the Promise with our own,
     // which starts the timer as soon as the task is actually started
-    var originalTimeout = resolver.promise.timeout
+    var originalTimeout = resolver.promise.timeout;
     resolver.promise.timeout = function timeout (delay) {
       if (tasks.indexOf(task) !== -1) {
         // task is still queued -> start the timer later on
@@ -110,7 +110,7 @@ Pool.prototype.exec = function (method, params) {
         // task is already being executed -> start timer immediately
         return originalTimeout.call(resolver.promise, delay);
       }
-    }
+    };
 
     // trigger task execution
     this._next();
@@ -204,6 +204,9 @@ Pool.prototype._next = function () {
         if (typeof task.timeout === 'number') {
           promise.timeout(task.timeout);
         }
+      } else {
+        // The task taken was already complete (either rejected or resolved), so just trigger next task in the queue
+        me._next();
       }
     }
   }


### PR DESCRIPTION
This is a simple bugfix. Can you please commit this change to source and tests, and create a new npm bundle.

If you would like to add me as a maintainer, please go ahead.