### PR TITLE
Add license field to a package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "workerpool",
+  "license": " Apache-2.0",
   "version": "2.3.1",
   "description": "Offload tasks to a pool of workers on node.js and in the browser",
   "homepage": "https://github.com/josdejong/workerpool",


### PR DESCRIPTION
Our company uses license checker tools which breaks build if it cannot get a license for the package. I believe this change would help to resolve license info automatically.