### PR TITLE
Add support for Yarn PnP

### DIFF
--- a/lib/WorkerHandler.js
+++ b/lib/WorkerHandler.js
@@ -42,6 +42,13 @@ function resolveForkOptions(opts) {
     }
   }
 
+  // if the host process is running using Yarn PnP we should start the
+  // child processes in the same mode
+  if (process.versions.pnp) {
+    var pnpPath = require.resolve('pnpapi');
+    execArgv.push(`--require ${pnpPath}`);
+  }
+
   return assign({}, opts, {
     forkArgs: opts.forkArgs,
     forkOpts: assign({}, opts.forkOpts, {


### PR DESCRIPTION
[Yarn Plug'n'Play](https://github.com/yarnpkg/rfcs/pull/101) is using a custom resolver to lookup dependencies from a machine-wide global location, instead of keeping `node_modules` duplicated in every project.

When `yarn run` is used and it detects that it is running in PnP mode it will call the child process using `--require .pnp.js`, with `.pnp.js` being a file generated per-project by Yarn. This will enable PnP mode for the child process and make the PnP API available via `require('pnpapi')`.

Since `workerpool` is also forking off child processes it would need a similar mechanism to ensure that those child processes are able to resolve their dependencies correctly. This PR adds the necessary `--require` argument to the fork option if PnP mode is detected by checking `process.versions.pnp`.

In case you're wondering: we're working on making [`ember-cli`](https://github.com/ember-cli/ember-cli) compatible with Yarn PnP and that is using [`broccoli-babel-transpiler`](https://github.com/babel/broccoli-babel-transpiler), which is using `workerpool` under the hood.

/cc @arcanis @rwjblue