### PR TITLE
[BUGFIX] nodeWorker: auto now can actually choose WorkerThreads

### DIFF
--- a/lib/WorkerHandler.js
+++ b/lib/WorkerHandler.js
@@ -53,6 +53,7 @@ function setupBrowserWorker(script, Worker) {
   // create the web worker
   var worker = new Worker(script);
 
+  worker.isBrowserWorker = true;
   // add node.js API to the web worker
   worker.on = function (event, callback) {
     this.addEventListener(event, function (message) {
@@ -70,6 +71,7 @@ function setupWorkerThreadWorker(script, WorkerThreads) {
     stdout: false, // automatically pipe worker.STDOUT to process.STDOUT
     stderr: false  // automatically pipe worker.STDERR to process.STDERR
   });
+  worker.isWorkerThread = true;
   // make the worker mimic a child_process
   worker.send = function(message) {
     this.postMessage(message);
@@ -88,11 +90,14 @@ function setupWorkerThreadWorker(script, WorkerThreads) {
 
 function setupProcessWorker(script, options, child_process) {
   // no WorkerThreads, fallback to sub-process based workers
-  return child_process.fork(
+  var worker = child_process.fork(
     script,
     options.forkArgs,
     options.forkOpts
   );
+
+  worker.isChildProcess = true;
+  return worker;
 }
 
 // add debug flags to child processes if the node inspector is active
@@ -162,6 +167,7 @@ function WorkerHandler(script, _options) {
       var WorkerThreads = ensureWorkerThreads();
       this.worker = setupWorkerThreadWorker(this.script, WorkerThreads);
     } else if (options.nodeWorker === 'auto') {
+      var WorkerThreads = tryRequire('worker_threads');
       if (WorkerThreads) {
         this.worker = setupWorkerThreadWorker(this.script, WorkerThreads);
       } else {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build": "gulp",
     "watch": "gulp watch",
     "test": "mocha test --timeout 10000",
+    "test:debug": "mocha debug test --timeout 10000",
     "coverage": "istanbul cover _mocha -- test; echo \"\nCoverage report is available at ./coverage/lcov-report/index.html\"",
     "prepublishOnly": "npm run build && npm run test"
   },

--- a/test/Pool.test.js
+++ b/test/Pool.test.js
@@ -31,17 +31,30 @@ describe('Pool', function () {
       return pool.exec(add, [3, 4])
     });
 
+    var WorkerThreads = tryRequire('worker_threads');
     it('supports auto', function() {
       var pool = new Pool({ nodeWorker: 'auto' });
-      return pool.exec(add, [3, 4])
+      var result = pool.exec(add, [3, 4]);
+      assert.equal(pool.workers.length, 1);
+      var worker = pool.workers[0].worker;
+
+      if (WorkerThreads) {
+        assert.equal(worker.isWorkerThread, true);
+      } else {
+        assert.equal(worker.isChildProcess, true);
+      }
+      return result;
     });
 
 
-    var WorkerThreads = tryRequire('worker_threads');
     if (WorkerThreads) {
       it('supports thread', function() {
         var pool = new Pool({ nodeWorker: 'thread' });
-        return pool.exec(add, [3, 4])
+        var work = pool.exec(add, [3, 4]);
+        assert.equal(pool.workers.length, 1);
+        var worker = pool.workers[0].worker;
+        assert.equal(worker.isWorkerThread, true);
+        return work;
       });
     } else {
       it('errors when not supporting worker thread', function() {


### PR DESCRIPTION
Oops, caught my mistake when trying to actually use workerpool \w `nodeWorker: 'auto'`.
Added tests, to validate.