### PR TITLE
Update documentation and examples for pool.terminate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ pool.exec(add, [3, 4])
       console.error(err);
     })
     .then(function () {
-      pool.terminate(); // terminate all workers when done
+      return pool.terminate(); // terminate all workers when done
     });
 ```
 
@@ -127,7 +127,7 @@ pool.exec('fibonacci', [10])
       console.error(err);
     })
     .then(function () {
-      pool.terminate(); // terminate all workers when done
+      return pool.terminate(); // terminate all workers when done
     });
 
 // or run registered functions on the worker via a proxy:
@@ -142,7 +142,7 @@ pool.proxy()
       console.error(err);
     })
     .then(function () {
-      pool.terminate(); // terminate all workers when done
+      return pool.terminate(); // terminate all workers when done
     });
 ```
 
@@ -221,9 +221,9 @@ A worker pool contains the following functions:
    }
    ```
 
-- `Pool.terminate([force: boolean [, timeout: number]])`
+- `Pool.terminate([force: boolean [, timeout: number]]) : Promise.<*, Error>`<br>
 
-  If parameter `force` is false (default), workers will finish the tasks they are working on before terminating themselves. When `force` is true, all workers are terminated immediately without finishing running tasks. If `timeout` is provided, worker will be forced to terminal when the timeout expires and the worker has not finished.
+  If parameter `force` is false (default), workers will finish the tasks they are working on before terminating themselves. When `force` is true, all workers are terminated immediately without finishing running tasks. If `timeout` is provided, worker will be forced to terminate when the timeout expires and the worker has not finished.
 
 - `Pool.clear([force: boolean])`<br>
   *Deprecated: use `Pool.terminate` instead*<br>.

--- a/examples/async.js
+++ b/examples/async.js
@@ -16,5 +16,5 @@ pool.proxy()
       console.error(err);
     })
     .then(function () {
-      pool.terminate(); // terminate all workers when done
+      return pool.terminate(); // terminate all workers when done
     });

--- a/examples/dedicatedWorker.js
+++ b/examples/dedicatedWorker.js
@@ -12,5 +12,5 @@ pool.exec('fibonacci', [10])
       console.error(err);
     })
     .then(function () {
-      pool.terminate(); // terminate all workers when done
+      return pool.terminate(); // terminate all workers when done
     });

--- a/examples/offloadFunctions.js
+++ b/examples/offloadFunctions.js
@@ -17,5 +17,5 @@ pool.exec(add, [3, 4])
       console.error(err);
     })
     .then(function () {
-      pool.terminate(); // terminate all workers when done
+      return pool.terminate(); // terminate all workers when done
     });

--- a/examples/proxy.js
+++ b/examples/proxy.js
@@ -16,5 +16,5 @@ pool.proxy()
       console.error(err);
     })
     .then(function () {
-      pool.terminate(); // terminate all workers when done
+      return pool.terminate(); // terminate all workers when done
     });


### PR DESCRIPTION
`pool.terminate` returns a Promise, but the documentation and examples treated it as if it were synchronous.

Fixes #56 