### PR TITLE
Improve worker exited unexpectedly error

### DIFF
--- a/lib/WorkerHandler.js
+++ b/lib/WorkerHandler.js
@@ -240,11 +240,23 @@ function WorkerHandler(script, _options) {
     me.requestQueue = [];
   }
 
+  var worker = this.worker;
   // listen for worker messages error and exit
   this.worker.on('error', onError);
-  this.worker.on('exit', function () {
-    var error = new Error('Worker terminated unexpectedly');
-    onError(error);
+  this.worker.on('exit', function (exitCode, signalCode) {
+    var message = 'Workerpool Worker terminated Unexpectedly\n';
+
+    message += '    exitCode: `' + exitCode + '`\n';
+    message += '    signalCode: `' + signalCode + '`\n';
+
+    message += '    workerpool.script: `' +  me.script + '`\n';
+    message += '    spawnArgs: `' +  worker.spawnargs + '`\n';
+    message += '    spawnfile: `' + worker.spawnfile + '`\n'
+
+    message += '    stdout: `' + worker.stdout + '`\n'
+    message += '    stderr: `' + worker.stderr + '`\n'
+
+    onError(new Error(message));
   });
 
   this.processing = Object.create(null); // queue with tasks currently in progress

--- a/test/Pool.test.js
+++ b/test/Pool.test.js
@@ -501,8 +501,15 @@ describe('Pool', function () {
         .then(function () {
           assert('Promise should not be resolved');
         })
-        .catch(function (err) {
-          assert.equal(err.toString(), 'Error: Worker terminated unexpectedly');
+      .catch(function (err) {
+          assert.ok(err.toString().match(/Error: Workerpool Worker terminated Unexpectedly/));
+          assert.ok(err.toString().match(/exitCode: `.*`/));
+          assert.ok(err.toString().match(/signalCode: `.*`/));
+          assert.ok(err.toString().match(/workerpool.script: `.*\.js`/));
+          assert.ok(err.toString().match(/spawnArgs: `.*\.js`/));
+          assert.ok(err.toString().match(/spawnfile: `.*node`/));
+          assert.ok(err.toString().match(/stdout: `null`/));
+          assert.ok(err.toString().match(/stderr: `null`/));
 
           assert.equal(pool.workers.length, 0);
 

--- a/test/WorkerHandler.test.js
+++ b/test/WorkerHandler.test.js
@@ -252,8 +252,15 @@ describe('WorkerHandler', function () {
         })
         .catch(function (err) {
           assert(err instanceof Error);
-          assert.ok(err.stack.match(/Error: Worker terminated unexpectedly/));
 
+          assert.ok(err.toString().match(/Error: Workerpool Worker terminated Unexpectedly/));
+          assert.ok(err.toString().match(/exitCode: `.*`/));
+          assert.ok(err.toString().match(/signalCode: `.*`/));
+          assert.ok(err.toString().match(/workerpool.script: `.*\.js`/));
+          assert.ok(err.toString().match(/spawnArgs: `.*\.js`/));
+          assert.ok(err.toString().match(/spawnfile: `.*node`/));
+          assert.ok(err.toString().match(/stdout: `null`/));
+          assert.ok(err.toString().match(/stderr: `null`/));
           done();
         });
 
@@ -270,7 +277,15 @@ describe('WorkerHandler', function () {
         })
         .catch(function (err) {
           assert(err instanceof Error);
-          assert.ok(err.stack.match(/Error: Worker terminated unexpectedly/));
+
+          assert.ok(err.stack.match(/Error: Workerpool Worker terminated Unexpectedly/));
+          assert.ok(err.stack.match(/exitCode: `.*`/));
+          assert.ok(err.stack.match(/signalCode: `.*`/));
+          assert.ok(err.stack.match(/workerpool.script: `.*\.js`/));
+          assert.ok(err.stack.match(/spawnArgs: `.*\.js`/));
+          assert.ok(err.stack.match(/spawnfile: `.*node`/));
+          assert.ok(err.stack.match(/stdout: `null`/));
+          assert.ok(err.stack.match(/stderr: `null`/));
 
           done();
         });


### PR DESCRIPTION
When a worker exits unexpectedly, it can be tricky to figure out why.
To improve debugging, I've added some additional information to the existing error message:

* the status code or signal code
* that workerpools script
* spawnargs
* spawnfile
* stdout
* stderr
 
example output:

```js
Error: Workerpool Worker terminated Unexpectedly
    exitCode: `12`
    workerpool.script: `/Users/spenner/src/josdejong/workerpool/lib/worker.js`
    spawnArgs: `/usr/local/Cellar/node/11.10.0/bin/node,--inspect=43210,/Users/spenner/src/josdejong/workerpool/lib/worker.js`
    spawnfile: `/usr/local/Cellar/node/11.10.0/bin/node`
    stdout: `null`
    stderr: `null`

    at ChildProcess.<anonymous> (/Users/spenner/src/josdejong/workerpool/lib/WorkerHandler.js:263:13)
    at ChildProcess.emit (events.js:197:13)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:254:12)
```