### PR TITLE
copy --max-old-space-size argv to fork options

### DIFF
--- a/lib/WorkerHandler.js
+++ b/lib/WorkerHandler.js
@@ -117,6 +117,12 @@ function resolveForkOptions(opts) {
     }
   }
 
+  process.execArgv.forEach(function(arg) {
+    if (arg.indexOf('--max-old-space-size') > -1) {
+      execArgv.push(arg)
+    }
+  })
+
   return assign({}, opts, {
     forkArgs: opts.forkArgs,
     forkOpts: assign({}, opts.forkOpts, {


### PR DESCRIPTION
my workers died with `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory`. This change copies over `--max-old-space-size=` to forkOpts.execArgv if set in `process.execArgv`.

![Screenshot from 2019-06-20 01-22-26](https://user-images.githubusercontent.com/3500621/59807864-01baa800-92fa-11e9-823b-60f3305c528f.png)
