### PR TITLE
Add support for a maximum task queue size

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -27,6 +27,7 @@ function Pool(script, options) {
   this.forkOpts = options.forkOpts || {};
   this.debugPortStart = (options.debugPortStart || 43210);
   this.nodeWorker = options.nodeWorker;
+  this.maxQueueSize = options.maxQueueSize || Number.MAX_SAFE_INTEGER;
 
   // configuration
   if (options && 'maxWorkers' in options) {
@@ -96,6 +97,10 @@ Pool.prototype.exec = function (method, params) {
 
   if (typeof method === 'string') {
     var resolver = Promise.defer();
+
+  if (this.tasks.length >= this.maxQueueSize) {
+    throw new Error(`Max queue size of ${this.maxQueueSize} reached`);
+  }
 
     // add a new task to the queue
     var tasks = this.tasks;


### PR DESCRIPTION
If the number of requests to the pool is too high, all the tasks are indefinitely added to the queue. In some cases it would be useful to have a limit to the queue size in order to keep the response time bounded to a predictable limit.