### PR TITLE
Missing nodeWorker option in _ensureMinWorkers method

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -345,7 +345,8 @@ Pool.prototype._ensureMinWorkers = function() {
       this.workers.push(new WorkerHandler(this.script, {
         forkArgs: this.forkArgs,
         forkOpts: this.forkOpts,
-        debugPort: DEBUG_PORT_ALLOCATOR.nextAvailableStartingAt(this.debugPortStart)
+        debugPort: DEBUG_PORT_ALLOCATOR.nextAvailableStartingAt(this.debugPortStart),
+        nodeWorker: this.nodeWorker
       }));
     }
   }


### PR DESCRIPTION
If the minWorkers option is set, workerpoll will always creates child processes at initialization, even though the nodeWorker option is `thread` or `auto`.

Ref: https://github.com/josdejong/workerpool/commit/571357e3e08007a5cec5442cb53b0b65e077f4e9#diff-1b589a05fcf1509343500faf9cd70bdaR247