### PR TITLE
Fix environment detection in browser

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -1,13 +1,14 @@
 var requireFoolWebpack = require('./requireFoolWebpack');
 
 // source: https://github.com/flexdinesh/browser-or-node
-module.exports.isNode = isNode = function (nodeProcess) {
+var isNode = function (nodeProcess) {
     return (
         typeof nodeProcess !== 'undefined' &&
         nodeProcess.versions != null &&
         nodeProcess.versions.node != null
     );
 }
+module.exports.isNode = isNode
 
 // determines the JavaScript platform: browser or node
 module.exports.platform = isNode(process)

--- a/src/environment.js
+++ b/src/environment.js
@@ -1,13 +1,16 @@
 var requireFoolWebpack = require('./requireFoolWebpack');
 
 // source: https://github.com/flexdinesh/browser-or-node
-var isNode = (
-    typeof process !== 'undefined' &&
-    process.versions != null &&
-    process.versions.node != null);
+module.exports.isNode = isNode = function (nodeProcess) {
+    return (
+        typeof nodeProcess !== 'undefined' &&
+        nodeProcess.versions != null &&
+        nodeProcess.versions.node != null
+    );
+}
 
 // determines the JavaScript platform: browser or node
-module.exports.platform = isNode
+module.exports.platform = isNode(process)
     ? 'node'
     : 'browser';
 

--- a/src/environment.js
+++ b/src/environment.js
@@ -3,7 +3,7 @@ var requireFoolWebpack = require('./requireFoolWebpack');
 // source: https://github.com/flexdinesh/browser-or-node
 var isNode = (
     typeof process !== 'undefined' &&
-    typeof process.versions != null &&
+    process.versions != null &&
     process.versions.node != null);
 
 // determines the JavaScript platform: browser or node

--- a/test/environment.test.js
+++ b/test/environment.test.js
@@ -1,0 +1,33 @@
+const assert = require('assert')
+const requireUncached = id => {
+    delete require.cache[require.resolve(id)]
+    return require(id)
+}
+
+const test = (process, test) => {
+    const backup = { process: global.process, self: global.self }
+    global.process = process
+    global.self = { navigator: { hardwareConcurrency: 8 } }
+    const environment = requireUncached('../src/environment')
+    Object.assign(global, backup)
+    test(environment, process)
+}
+
+const shouldBeBrowser = env => {
+    it('is platform assigned to be browser', function () {
+        assert.strictEqual(env.platform, 'browser')
+    })
+}
+
+const shouldBeNode = env => {
+    it('is platform assigned to be node', function () {
+        assert.strictEqual(env.platform, 'node')
+    })
+}
+
+describe('should distinguish environment', function () {
+    test(undefined, shouldBeBrowser)
+    test({}, shouldBeBrowser)
+    test({ versions: {} }, shouldBeBrowser)
+    test({ versions: { node: '10.0.0' } }, shouldBeNode)
+})

--- a/test/environment.test.js
+++ b/test/environment.test.js
@@ -1,23 +1,13 @@
 const assert = require('assert')
 const isNode = require('../src/environment').isNode
 
-const test = (process, should) => should(isNode(process))
-
-const shouldBeBrowser = isNode => {
+describe('Environment Detection', function () {
     it('is platform assigned to be browser', function () {
-        assert.strictEqual(isNode, false)
+        assert.strictEqual(isNode(undefined), false)
+        assert.strictEqual(isNode({}), false)
+        assert.strictEqual(isNode({ versions: {} }), false)
     })
-}
-
-const shouldBeNode = isNode => {
     it('is platform assigned to be node', function () {
-        assert.strictEqual(isNode, true)
+        assert.strictEqual(isNode({ versions: { node: '10.0.0' } }), true)
     })
-}
-
-describe('should distinguish environment', function () {
-    test(undefined, shouldBeBrowser)
-    test({}, shouldBeBrowser)
-    test({ versions: {} }, shouldBeBrowser)
-    test({ versions: { node: '10.0.0' } }, shouldBeNode)
 })

--- a/test/environment.test.js
+++ b/test/environment.test.js
@@ -1,27 +1,17 @@
 const assert = require('assert')
-const requireUncached = id => {
-    delete require.cache[require.resolve(id)]
-    return require(id)
-}
+const isNode = require('../src/environment').isNode
 
-const test = (process, test) => {
-    const backup = { process: global.process, self: global.self }
-    global.process = process
-    global.self = { navigator: { hardwareConcurrency: 8 } }
-    const environment = requireUncached('../src/environment')
-    Object.assign(global, backup)
-    test(environment, process)
-}
+const test = (process, should) => should(isNode(process))
 
-const shouldBeBrowser = env => {
+const shouldBeBrowser = isNode => {
     it('is platform assigned to be browser', function () {
-        assert.strictEqual(env.platform, 'browser')
+        assert.strictEqual(isNode, false)
     })
 }
 
-const shouldBeNode = env => {
+const shouldBeNode = isNode => {
     it('is platform assigned to be node', function () {
-        assert.strictEqual(env.platform, 'node')
+        assert.strictEqual(isNode, true)
     })
 }
 


### PR DESCRIPTION
`typeof process.versions != null` will fail if `process` is a defined variable, for example, browser environment with improper webpack bundled