### PR TITLE
export source for node and unminified for browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "pool",
     "isomorphic"
   ],
-  "main": "dist/workerpool.min.js",
+  "main": "src/index.js",
+  "browser": "dist/workerpool.js",
   "files": [
     "dist",
     "examples",


### PR DESCRIPTION
Hi,

over at [Mocha](/mochajs/mocha) we're looking to add support for parallel testing (mochajs/mocha#4245), and I've chosen `workerpool` to help manage this for us.

I noticed when debugging that this project is shipping a `.min.js` file to Node.js users.  This isn't necessary, and can make debugging awkward.

This PR changes the main export in Node.js to be the source entry point: `src/index.js`.  I've added the `browser` field to point to `dist/workerpool.min.js`.

Also:

Those building browser apps will often do their own minification.  For those apps which do not, it can make sense to ship a minified version--but it doen't need to be the main export.  I _have not changed_ the default browser export to `dist/workerpool.js` (which it likely should be) because it too needs a source map (pointing back to the files in `src/`), and I wasn't sure how to configure that in the gulpfile.

 