### PR TITLE
Allow passing of options to worker threads

### DIFF
--- a/src/Pool.js
+++ b/src/Pool.js
@@ -29,7 +29,6 @@ function Pool(script, options) {
   this.nodeWorker = options.nodeWorker;
   this.workerType = options.workerType || options.nodeWorker || 'auto'
   this.maxQueueSize = options.maxQueueSize || Infinity;
-  this.workerThreadOpts = options.workerThreadOpts || {};
   this.processOrWorkerOpts = options.processOrWorkerOpts || {}
 
   // configuration

--- a/src/Pool.js
+++ b/src/Pool.js
@@ -29,6 +29,7 @@ function Pool(script, options) {
   this.nodeWorker = options.nodeWorker;
   this.workerType = options.workerType || options.nodeWorker || 'auto'
   this.maxQueueSize = options.maxQueueSize || Infinity;
+  this.workerThreadOpts = options.workerThreadOpts || {};
 
   // configuration
   if (options && 'maxWorkers' in options) {
@@ -367,7 +368,8 @@ Pool.prototype._createWorkerHandler = function () {
     forkArgs: this.forkArgs,
     forkOpts: this.forkOpts,
     debugPort: DEBUG_PORT_ALLOCATOR.nextAvailableStartingAt(this.debugPortStart),
-    workerType: this.workerType
+    workerType: this.workerType,
+    workerThreadOpts: this.workerThreadOpts,
   });
 }
 

--- a/src/Pool.js
+++ b/src/Pool.js
@@ -30,6 +30,7 @@ function Pool(script, options) {
   this.workerType = options.workerType || options.nodeWorker || 'auto'
   this.maxQueueSize = options.maxQueueSize || Infinity;
   this.workerThreadOpts = options.workerThreadOpts || {};
+  this.processOrWorkerOpts = options.processOrWorkerOpts || {}
 
   // configuration
   if (options && 'maxWorkers' in options) {
@@ -369,7 +370,7 @@ Pool.prototype._createWorkerHandler = function () {
     forkOpts: this.forkOpts,
     debugPort: DEBUG_PORT_ALLOCATOR.nextAvailableStartingAt(this.debugPortStart),
     workerType: this.workerType,
-    workerThreadOpts: this.workerThreadOpts,
+    processOrWorkerOpts: this.processOrWorkerOpts,
   });
 }
 

--- a/src/WorkerHandler.js
+++ b/src/WorkerHandler.js
@@ -73,7 +73,7 @@ function setupWorker(script, options) {
     return setupBrowserWorker(script, Worker);
   } else if (options.workerType === 'thread') { // node.js only
     WorkerThreads = ensureWorkerThreads();
-    return setupWorkerThreadWorker(script, WorkerThreads);
+    return setupWorkerThreadWorker(script, WorkerThreads, options.workerThreadOpts);
   } else if (options.workerType === 'process' || !options.workerType) { // node.js only
     return setupProcessWorker(script, resolveForkOptions(options), requireFoolWebpack('child_process'));
   } else { // options.workerType === 'auto' or undefined
@@ -109,11 +109,16 @@ function setupBrowserWorker(script, Worker) {
   return worker;
 }
 
-function setupWorkerThreadWorker(script, WorkerThreads) {
-  var worker = new WorkerThreads.Worker(script, {
+function setupWorkerThreadWorker(script, WorkerThreads, workerThreadOpts) {
+  
+  var default_opts = {
     stdout: false, // automatically pipe worker.STDOUT to process.STDOUT
     stderr: false  // automatically pipe worker.STDERR to process.STDERR
-  });
+  };
+  
+  workerThreadOpts = workerThreadOpts || default_opts;
+  
+  var worker = new WorkerThreads.Worker(script, workerThreadOpts);
   worker.isWorkerThread = true;
   // make the worker mimic a child_process
   worker.send = function(message) {


### PR DESCRIPTION
With this change, you can pass your own options for a Worker.

Just add all your custom worker thread specific options to the `workerThreadOpts` field of the `options` passed in Pools.

For example --

`const pool = workerpool.pool(__dirname + '/myWorker.js', {workerThreadOpts: {stdout: false, stderr: false}});`

If no workerThreadOpts passed in options of workerpool.pool, then the default `{stdout: false, stderr: false}` will be used.

Options that you can now pass to `workerThreadOpts` are -- https://nodejs.org/api/worker_threads.html#worker_threads_new_worker_filename_options