### PR TITLE
disregard messages from terminated workers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workerpool",
   "license": "Apache-2.0",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "description": "Offload tasks to a pool of workers on node.js and in the browser",
   "homepage": "https://github.com/josdejong/workerpool",
   "author": "Jos de Jong <wjosdejong@gmail.com> (https://github.com/josdejong)",

--- a/src/WorkerHandler.js
+++ b/src/WorkerHandler.js
@@ -216,6 +216,9 @@ function WorkerHandler(script, _options) {
   // queue for requests that are received before the worker is ready
   this.requestQueue = [];
   this.worker.on('message', function (response) {
+    if (me.terminated) {
+      return;
+    }
     if (typeof response === 'string' && response === 'ready') {
       me.worker.ready = true;
       dispatchQueuedRequests();

--- a/test/WorkerHandler.test.js
+++ b/test/WorkerHandler.test.js
@@ -464,4 +464,15 @@ describe('WorkerHandler', function () {
       });
     });
   });
+
+  describe('workerAlreadyTerminated', function () {
+    it('worker handler checks if terminated before handling message', function (done) {
+      var handler = new WorkerHandler();
+      const worker = handler.worker;
+      handler.worker = null;
+      handler.terminated = true;
+      worker.emit('message', 'ready');
+      done();
+    });
+  });
 });

--- a/test/WorkerHandler.test.js
+++ b/test/WorkerHandler.test.js
@@ -469,10 +469,10 @@ describe('WorkerHandler', function () {
     it('worker handler checks if terminated before handling message', function (done) {
       var handler = new WorkerHandler();
       const worker = handler.worker;
-      handler.worker = null;
-      handler.terminated = true;
-      worker.emit('message', 'ready');
-      done();
+      handler.terminate(true, () => {
+        worker.emit('message', 'ready');
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
credit / source: https://github.com/josdejong/workerpool/pull/160 

didn't have access so decided to make my own PR (more than happy to work with the Madgvox to get the unit test on the original PR so credit is appropriately given, but couldn't seem to @ the user here, so I'll let @josdejong, you decide what you want to do).

Anyways - like the linked PR says, solves [#147 ](https://github.com/josdejong/workerpool/issues/147)

After lots of digging, this unit test seemed best to me, in terms of being simple and targeted. Happy to discuss if you think this doesn't cover the case. 

Note: you can test this by commenting out the below code block found in `WorkerHandler.js` and this new unit test should fail.

```
if (me.terminated) {
    return;
}
```

potentially related to this [PR](https://github.com/josdejong/workerpool/pull/265) - maybe a good idea to review that linked PR before deciding on whether or not to merge this one in.