### PR TITLE
remove all 'message' event listeners when terminating a worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workerpool",
   "license": "Apache-2.0",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "description": "Offload tasks to a pool of workers on node.js and in the browser",
   "homepage": "https://github.com/josdejong/workerpool",
   "author": "Jos de Jong <wjosdejong@gmail.com> (https://github.com/josdejong)",

--- a/src/WorkerHandler.js
+++ b/src/WorkerHandler.js
@@ -400,6 +400,7 @@ WorkerHandler.prototype.terminate = function (force, callback) {
     // all tasks are finished. kill the worker
     var cleanup = function(err) {
       me.terminated = true;
+      me.worker.removeAllListeners('message');
       me.worker = null;
       me.terminating = false;
       if (me.terminationHandler) {

--- a/src/WorkerHandler.js
+++ b/src/WorkerHandler.js
@@ -400,7 +400,9 @@ WorkerHandler.prototype.terminate = function (force, callback) {
     // all tasks are finished. kill the worker
     var cleanup = function(err) {
       me.terminated = true;
-      me.worker.removeAllListeners('message');
+      if (!(me.worker == null)) {
+        me.worker.removeAllListeners('message');
+      }
       me.worker = null;
       me.terminating = false;
       if (me.terminationHandler) {

--- a/src/WorkerHandler.js
+++ b/src/WorkerHandler.js
@@ -400,7 +400,7 @@ WorkerHandler.prototype.terminate = function (force, callback) {
     // all tasks are finished. kill the worker
     var cleanup = function(err) {
       me.terminated = true;
-      if (!(me.worker == null)) {
+      if (me.worker != null) {
         me.worker.removeAllListeners('message');
       }
       me.worker = null;

--- a/src/WorkerHandler.js
+++ b/src/WorkerHandler.js
@@ -216,6 +216,9 @@ function WorkerHandler(script, _options) {
   // queue for requests that are received before the worker is ready
   this.requestQueue = [];
   this.worker.on('message', function (response) {
+    if (me.terminated) {
+      return;
+    }
     if (typeof response === 'string' && response === 'ready') {
       me.worker.ready = true;
       dispatchQueuedRequests();

--- a/test/WorkerHandler.test.js
+++ b/test/WorkerHandler.test.js
@@ -464,4 +464,15 @@ describe('WorkerHandler', function () {
       });
     });
   });
+
+  describe('workerAlreadyTerminated', function () {
+    it('worker handler checks if terminated before handling message', function (done) {
+      var handler = new WorkerHandler();
+      const worker = handler.worker;
+      handler.terminate(true, () => {
+        worker.emit('message', 'ready');
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
solves #147 

 Related to / potentially is not required if this [PR #264](https://github.com/josdejong/workerpool/pull/264) is merged in -> But I was thinking maybe the cleanest solution was to actually ensure that we properly clean up event listeners for the terminated workers, rather than checking if the `WorkerHandler` is `terminated` within the event listener.

I'll leave it up to @josdejong to decide which solution you like better or if you think both PRs should be merged 🤷 