### PR TITLE
Allow forkOpts to be computed dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,14 @@ The following options are available:
   - In case of `'web'`, a Web Worker will be used. Only available in a browser environment.
   - In case of `'process'`, `child_process` will be used. Only available in a node.js environment.
   - In case of `'thread'`, `worker_threads` will be used. If `worker_threads` are not available, an error is thrown. Only available in a node.js environment.
+- `forkArgs: String[]`. For `process` worker type. An array passed as `args` to [child_process.fork](https://nodejs.org/api/child_process.html#child_processforkmodulepath-args-options)
+- `forkOpts: Object`. For `process` worker type. An object passed as `options` to [child_process.fork](https://nodejs.org/api/child_process.html#child_processforkmodulepath-args-options). See nodejs documentation for available options.
+- `onCreateWorker: Function`. A callback that is called whenever a worker is being created. It can be used to allocate resources for each worker for example. The callback is passed as argument an object with the following properties:
+  - `forkArgs: String[]`: the `forkArgs` option of this pool
+  - `forkOpts: Object`: the `forkOpts` option of this pool
+  - `script: string`: the `script` option of this pool
+  Optionally, this callback can return an object containing one or more of the above properties. The provided properties will be used to override the Pool properties for the worker being created. 
+- `onTerminateWorker: Function`. A callback that is called whenever a worker is being terminated. It can be used to release resources that might have been allocated for this specific worker. The callback is passed as argument an object as described for `onCreateWorker`, with each property sets with the value for the worker being terminated. 
 
 > Important note on `'workerType'`: when sending and receiving primitive data types (plain JSON) from and to a worker, the different worker types (`'web'`, `'process'`, `'thread'`) can be used interchangeably. However, when using more advanced data types like buffers, the API and returned results can vary. In these cases, it is best not to use the `'auto'` setting but have a fixed `'workerType'` and good unit testing in place.
 

--- a/src/WorkerHandler.js
+++ b/src/WorkerHandler.js
@@ -207,6 +207,8 @@ function WorkerHandler(script, _options) {
   this.script = script || getDefaultWorker();
   this.worker = setupWorker(this.script, options);
   this.debugPort = options.debugPort;
+  this.forkOpts = options.forkOpts;
+  this.forkArgs = options.forkArgs;
 
   // The ready message is only sent if the worker.add method is called (And the default script is not used)
   if (!script) {

--- a/src/types.js
+++ b/src/types.js
@@ -6,7 +6,8 @@
  * @property {'auto' | 'web' | 'process' | 'thread'} [workerType]
  * @property {*} [forkArgs]
  * @property {*} [forkOpts]
- * @property {number} [debugPortStart]
+ * @property {Function} [onCreateWorker]
+ * @property {Function} [onTerminateWorker]
  */
 
 /**


### PR DESCRIPTION
Hello, 

I added this to be able use cases where I needed to attributed some unique identifiers to all workers in the pool.

What do you think?