### PR TITLE
Ensure pools are terminated after each test

### DIFF
--- a/test/Pool.test.js
+++ b/test/Pool.test.js
@@ -9,13 +9,26 @@ function add(a, b) {
 
 describe('Pool', function () {
 
+  // Creating pool with this function ensures that the pool is terminated
+  // at the end of the test, which avoid hanging the test suite if terminate()
+  // hadn't been called for some reasons
+  function createPool(poolParameters) {
+    var pool = new Pool(poolParameters);
+
+    after(() => {
+      return pool.terminate();
+    });
+
+    return pool;
+  }
+
   describe('nodeWorker', function() {
     function add(a,b) {
       return a+b;
     }
 
     it('supports process', function() {
-      var pool = new Pool({ workerType: 'process' });
+      var pool = createPool({ workerType: 'process' });
 
       return pool.exec(add, [3, 4])
           .then(function (result) {
@@ -28,7 +41,7 @@ describe('Pool', function () {
     var WorkerThreads = tryRequire('worker_threads');
 
     it('supports auto', function() {
-      var pool = new Pool({ workerType: 'auto' });
+      var pool = createPool({ workerType: 'auto' });
       var promise = pool.exec(add, [3, 4]);
       assert.strictEqual(pool.workers.length, 1);
       var worker = pool.workers[0].worker;
@@ -48,7 +61,7 @@ describe('Pool', function () {
 
     if (WorkerThreads) {
       it('supports thread', function() {
-        var pool = new Pool({ workerType: 'thread' });
+        var pool = createPool({ workerType: 'thread' });
         var promise = pool.exec(add, [3, 4]);
 
         assert.strictEqual(pool.workers.length, 1);
@@ -64,14 +77,14 @@ describe('Pool', function () {
     } else {
       it('errors when not supporting worker thread', function() {
         assert.throws(function() {
-          new Pool({ workerType: 'thread' });
+          createPool({ workerType: 'thread' });
         }, /WorkerPool: workerType = 'thread' is not supported, Node >= 11\.7\.0 required/)
       });
     }
   })
 
   it('supports forkOpts parameter to pass options to fork', function() {
-    var pool = new Pool({ workerType: 'process', forkOpts: { env: { TEST_ENV: 'env_value'} } });
+    var pool = createPool({ workerType: 'process', forkOpts: { env: { TEST_ENV: 'env_value'} } });
     function getEnv() {
       return process.env.TEST_ENV;
     }
@@ -87,7 +100,7 @@ describe('Pool', function () {
   it('supports worker creation hook to pass dynamic options to fork (for example)', function() {
     var counter = 0;
     var terminatedWorkers = [];
-    var pool = new Pool({
+    var pool = createPool({
       workerType: 'process',
       maxWorkers: 4, // make sure we can create enough workers (otherwise we could be limited by the number of CPUs)
       onCreateWorker: (opts) => {
@@ -117,16 +130,11 @@ describe('Pool', function () {
       assert(terminatedWorkers.includes('env_value0'), 'terminatedWorkers should include the value with counter = 0');
       assert(terminatedWorkers.includes('env_value1'), 'terminatedWorkers should include the value with counter = 1');
       assert(terminatedWorkers.includes('env_value2'), 'terminatedWorkers should include the value with counter = 2');
-    }).catch(function (error) {
-      // correctly terminate the pool in case of error to avoid hanging the tests forever
-      return pool.terminate().then(function() {
-        throw error;
-      });
     });
   });
 
   it('should offload a function to a worker', function (done) {
-    var pool = new Pool({maxWorkers: 10});
+    var pool = createPool({maxWorkers: 10});
 
     function add(a, b) {
       return a + b;
@@ -150,7 +158,7 @@ describe('Pool', function () {
   });
 
   it('should offload functions to multiple workers', function (done) {
-    var pool = new Pool({maxWorkers: 10});
+    var pool = createPool({maxWorkers: 10});
 
     function add(a, b) {
       return a + b;
@@ -174,7 +182,7 @@ describe('Pool', function () {
   });
 
   it('should put tasks in queue when all workers are busy', function (done) {
-    var pool = new Pool({maxWorkers: 2});
+    var pool = createPool({maxWorkers: 2});
 
     function add(a, b) {
       return a + b;
@@ -212,7 +220,7 @@ describe('Pool', function () {
   });
 
   it('should create a proxy', function (done) {
-    var pool = new Pool();
+    var pool = createPool();
 
     pool.proxy().then(function (proxy) {
       assert.deepStrictEqual(Object.keys(proxy).sort(), ['methods', 'run']);
@@ -231,7 +239,7 @@ describe('Pool', function () {
   });
 
   it('should create a proxy of a custom worker', function (done) {
-    var pool = new Pool(__dirname + '/workers/simple.js');
+    var pool = createPool(__dirname + '/workers/simple.js');
 
     pool.proxy().then(function (proxy) {
       assert.deepStrictEqual(Object.keys(proxy).sort(), ['add','methods','multiply','run','timeout']);
@@ -242,7 +250,7 @@ describe('Pool', function () {
   });
 
   it('should invoke a method via a proxy', function (done) {
-    var pool = new Pool(__dirname + '/workers/simple.js');
+    var pool = createPool(__dirname + '/workers/simple.js');
 
     pool.proxy().then(function (proxy) {
       proxy.multiply(4, 3)
@@ -260,7 +268,7 @@ describe('Pool', function () {
   });
 
   it('should invoke an async method via a proxy', function (done) {
-    var pool = new Pool(__dirname + '/workers/simple.js');
+    var pool = createPool(__dirname + '/workers/simple.js');
 
     pool.proxy().then(function (proxy) {
       proxy.timeout(100)
@@ -278,7 +286,7 @@ describe('Pool', function () {
   });
 
   it('should handle errors thrown by a worker', function (done) {
-    var pool = new Pool({maxWorkers: 10});
+    var pool = createPool({maxWorkers: 10});
 
     function test() {
       throw new TypeError('Test error');
@@ -295,7 +303,7 @@ describe('Pool', function () {
   });
 
   it('should execute a function returning a Promise', function (done) {
-    var pool = new Pool({maxWorkers: 10});
+    var pool = createPool({maxWorkers: 10});
 
     function testAsync() {
       return Promise.resolve('done');
@@ -314,7 +322,7 @@ describe('Pool', function () {
   });
 
   it('should propagate a rejected Promise', function (done) {
-    var pool = new Pool({maxWorkers: 10});
+    var pool = createPool({maxWorkers: 10});
 
     function testAsync() {
       return Promise.reject(new Error('I reject!'));
@@ -333,7 +341,7 @@ describe('Pool', function () {
   });
 
   it('should cancel a task', function (done) {
-    var pool = new Pool({maxWorkers: 10});
+    var pool = createPool({maxWorkers: 10});
 
     function forever() {
       while (1 > 0) {} // runs forever
@@ -358,7 +366,7 @@ describe('Pool', function () {
   });
 
   it('should cancel a queued task', function (done) {
-    var pool = new Pool({maxWorkers: 1});
+    var pool = createPool({maxWorkers: 1});
     var reachedTheEnd = false;
 
     function delayed() {
@@ -404,7 +412,7 @@ describe('Pool', function () {
 
   it('should run following tasks if a previous queued task is cancelled', function (done) {
 
-    var pool = new Pool({maxWorkers: 1});
+    var pool = createPool({maxWorkers: 1});
     var reachedTheEnd = false;
 
     function delayed() {
@@ -482,7 +490,7 @@ describe('Pool', function () {
     // TODO: test whether a task in the queue can be neatly cancelled
 
   it('should timeout a task', function () {
-    var pool = new Pool({maxWorkers: 10});
+    var pool = createPool({maxWorkers: 10});
 
     function forever() {
       while (1 > 0) {} // runs forever
@@ -502,7 +510,7 @@ describe('Pool', function () {
   });
 
   it('should start timeout timer of a task once the task is taken from the queue (1)', function (done) {
-    var pool = new Pool({maxWorkers: 1});
+    var pool = createPool({maxWorkers: 1});
     var delay = 50
 
     function sleep() {
@@ -540,7 +548,7 @@ describe('Pool', function () {
   });
 
   it('should start timeout timer of a task once the task is taken from the queue (2)', function (done) {
-    var pool = new Pool({maxWorkers: 1});
+    var pool = createPool({maxWorkers: 1});
     var delay = 50
 
     function sleep() {
@@ -568,7 +576,7 @@ describe('Pool', function () {
   });
 
   it('should handle crashed workers (1)', function () {
-    var pool = new Pool({maxWorkers: 1});
+    var pool = createPool({maxWorkers: 1});
 
     var promise = pool.exec(add)
       .then(function () {
@@ -593,13 +601,6 @@ describe('Pool', function () {
         assert.strictEqual(pool.workers.length, 1);
 
         return pool.terminate();
-      })
-      .catch(function (err) {
-        // Promise library lacks a "finally"
-        return pool.terminate()
-          .then(function() {
-            return err;
-          });
       });
 
     assert.strictEqual(pool.workers.length, 1);
@@ -616,24 +617,24 @@ describe('Pool', function () {
 
     it('should throw an error on invalid type or number of maxWorkers', function () {
       assert.throws(function () {
-        new Pool({maxWorkers: 'a string'});
+        createPool({maxWorkers: 'a string'});
       }, TypeError);
 
       assert.throws(function () {
-        new Pool({maxWorkers: 2.5});
+        createPool({maxWorkers: 2.5});
       }, TypeError);
 
       assert.throws(function () {
-        new Pool({maxWorkers: 0});
+        createPool({maxWorkers: 0});
       }, TypeError);
 
       assert.throws(function () {
-        new Pool({maxWorkers: -1});
+        createPool({maxWorkers: -1});
       }, TypeError);
     });
 
     it('should limit to the configured number of max workers', function () {
-      var pool = new Pool({maxWorkers: 2});
+      var pool = createPool({maxWorkers: 2});
 
       var tasks = [
         pool.exec(add, [1, 2]),
@@ -653,7 +654,7 @@ describe('Pool', function () {
     });
 
     it('should take number of cpus minus one as default maxWorkers', function () {
-      var pool = new Pool();
+      var pool = createPool();
 
       var cpus = require('os').cpus();
       assert.strictEqual(pool.maxWorkers, cpus.length - 1);
@@ -663,20 +664,20 @@ describe('Pool', function () {
 
     it('should throw an error on invalid type or number of minWorkers', function () {
       assert.throws(function () {
-        new Pool({minWorkers: 'a string'});
+        createPool({minWorkers: 'a string'});
       }, TypeError);
 
       assert.throws(function () {
-        new Pool({minWorkers: 2.5});
+        createPool({minWorkers: 2.5});
       }, TypeError);
 
       assert.throws(function () {
-        new Pool({maxWorkers: -1});
+        createPool({maxWorkers: -1});
       }, TypeError);
     });
 
     it('should create number of cpus minus one when minWorkers set to \'max\'', function () {
-      var pool = new Pool({minWorkers:'max'});
+      var pool = createPool({minWorkers:'max'});
 
       var cpus = require('os').cpus();
       assert.strictEqual(pool.workers.length, cpus.length - 1);
@@ -685,7 +686,7 @@ describe('Pool', function () {
     });
 
     it('should increase maxWorkers to match minWorkers', function () {
-      var pool = new Pool({minWorkers: 16});
+      var pool = createPool({minWorkers: 16});
 
       var tasks = []
       for(var i=0;i<20;i++) {
@@ -708,7 +709,7 @@ describe('Pool', function () {
   });
 
   it('should clear all workers upon explicit termination', function (done) {
-    var pool = new Pool({maxWorkers: 10});
+    var pool = createPool({maxWorkers: 10});
 
     assert.strictEqual(pool.workers.length, 0);
 
@@ -736,7 +737,7 @@ describe('Pool', function () {
 
 
   it('should wait until subprocesses have ended', function (done) {
-    var pool = new Pool({maxWorkers: 10, workerType: 'process'});
+    var pool = createPool({maxWorkers: 10, workerType: 'process'});
 
     assert.strictEqual(pool.workers.length, 0);
 
@@ -772,7 +773,7 @@ describe('Pool', function () {
   });
 
   it('should clear all workers after tasks are finished', function () {
-    var pool = new Pool({maxWorkers: 10});
+    var pool = createPool({maxWorkers: 10});
 
     assert.strictEqual(pool.workers.length, 0);
 
@@ -797,7 +798,7 @@ describe('Pool', function () {
 
   it ('should wait for all workers if pool is terminated before multiple concurrent tasks are finished', function (done) {
 
-    var pool = new Pool({maxWorkers: 10});
+    var pool = createPool({maxWorkers: 10});
 
     assert.strictEqual(pool.workers.length, 0);
 
@@ -854,7 +855,7 @@ describe('Pool', function () {
 
   it ('should wait for all workers if pool is terminated before tasks are finished, even if a task fails', function (done) {
 
-    var pool = new Pool({maxWorkers: 10});
+    var pool = createPool({maxWorkers: 10});
 
     assert.strictEqual(pool.workers.length, 0);
 
@@ -898,7 +899,7 @@ describe('Pool', function () {
   });
 
   it ('should cancel any pending tasks when terminating a pool', function () {
-    var pool = new Pool({maxWorkers: 1});
+    var pool = createPool({maxWorkers: 1});
 
     assert.strictEqual(pool.workers.length, 0);
 
@@ -932,7 +933,7 @@ describe('Pool', function () {
   });
 
   it('should return statistics', function () {
-    var pool = new Pool({maxWorkers: 4});
+    var pool = createPool({maxWorkers: 4});
 
     function test() {
       return new Promise(function (resolve, reject) {
@@ -983,7 +984,7 @@ describe('Pool', function () {
   });
 
   it('should throw an error in case of wrong type of arguments in function exec', function () {
-    var pool = new Pool();
+    var pool = createPool();
     assert.throws(function () {pool.exec()}, TypeError);
     assert.throws(function () {pool.exec(23)}, TypeError);
     assert.throws(function () {pool.exec(add, {})}, TypeError);
@@ -992,7 +993,7 @@ describe('Pool', function () {
   });
 
   it('should throw an error when the tasks queue is full', function () {
-    var pool = new Pool({maxWorkers: 2, maxQueueSize: 3});
+    var pool = createPool({maxWorkers: 2, maxQueueSize: 3});
 
     function add(a, b) {
       return a + b;
@@ -1032,7 +1033,7 @@ describe('Pool', function () {
   });
 
   it('should receive events from worker', function (done) {
-    var pool = new Pool(__dirname + '/workers/emit.js');
+    var pool = createPool(__dirname + '/workers/emit.js');
 
     var receivedEvent
 


### PR DESCRIPTION
As discussed in a previous PR, this avoids hanging the test suite in case terminate() is not called (which may happen on some failure case)