### PR TITLE
Fix examples/embeddedWorker

### DIFF
--- a/examples/embeddedWorker/createEmbeddedWorker.js
+++ b/examples/embeddedWorker/createEmbeddedWorker.js
@@ -36,6 +36,13 @@ function createWorkerBundle(workerFile, workerBundleFile) {
         filename: workerBundleFile,
         path: __dirname
       },
+      resolve: {
+        fallback: {
+          "os": false,
+          "child_process": false,
+          "worker_threads": false
+        }
+      },
       mode: 'production'
     };
 

--- a/examples/embeddedWorker/package.json
+++ b/examples/embeddedWorker/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build-embedded-worker": "node createEmbeddedWorker.js",
-    "build-app": "webpack ./app.js -o ./dist --mode=production",
+    "build-app": "webpack --config webpack.config.cjs",
     "build": "npm run build-embedded-worker && npm run build-app"
   },
   "dependencies": {},

--- a/examples/embeddedWorker/webpack.config.cjs
+++ b/examples/embeddedWorker/webpack.config.cjs
@@ -1,0 +1,15 @@
+const path = require("path");
+module.exports = {
+    mode: "production",
+    entry: path.resolve(__dirname, './app.js'),
+    resolve: {
+        fallback: {
+            "os": false,
+            "child_process": false,
+            "worker_threads": false
+        }
+    },
+    optimization: {
+        minimize: false
+    }
+};


### PR DESCRIPTION
Fix `examples/embeddedWorker`. The current one doesn't work with webpack 5.

