### PR TITLE
Generate types from JSDoc comments with TypeScript compiler.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+types
+
 # Logs
 logs
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-types
+/types
 
 # Logs
 logs

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,14 @@
         "@rollup/plugin-json": "6.0.1",
         "@rollup/plugin-node-resolve": "15.2.3",
         "@rollup/plugin-terser": "0.4.4",
+        "@types/node": "20.10.4",
         "c8": "8.0.1",
         "date-format": "4.0.14",
         "find-process": "1.4.7",
         "fs-extra": "11.2.0",
         "mocha": "10.2.0",
-        "rollup": "4.6.1"
+        "rollup": "4.6.1",
+        "typescript": "5.3.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2081,6 +2083,15 @@
       "integrity": "sha512-zONci81DZYCZjiLe0r6equvZut0b+dBRPBN5kBDjsONnutYNtJMoWQ9uR2RkL1gLG9NMTzvf+29e5RFfPbeKhQ==",
       "dev": true
     },
+    "node_modules/@types/node": {
+      "version": "20.10.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
+      "integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -4014,6 +4025,25 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -27,13 +27,14 @@
     "README.md"
   ],
   "scripts": {
-    "build": "rollup -c rollup.config.mjs",
+    "build": "rollup -c rollup.config.mjs && npm run build:types",
+    "build:types": "tsc -p .",
     "watch": "rollup -c rollup.config.mjs -w",
-    "test": "npm run build && mocha test",
+    "test": "npm run build && mocha test && npm run test:types",
+    "test:types": "tsc -p test/types",
     "test:debug": "npm run build && mocha debug test",
     "coverage": "npm run build && c8 mocha && c8 report --reporter=html && echo Coverage report is available at ./coverage/index.html",
-    "prepublishOnly": "npm run test",
-    "types": "tsc -p ."
+    "prepublishOnly": "npm run test"
   },
   "devDependencies": {
     "@types/node": "20.10.4",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "main": "src/index.js",
   "browser": "dist/workerpool.js",
+  "types": "types/index.d.ts",
   "files": [
     "dist",
     "src",
@@ -31,9 +32,11 @@
     "test": "npm run build && mocha test",
     "test:debug": "npm run build && mocha debug test",
     "coverage": "npm run build && c8 mocha && c8 report --reporter=html && echo Coverage report is available at ./coverage/index.html",
-    "prepublishOnly": "npm run test"
+    "prepublishOnly": "npm run test",
+    "types": "tsc -p ."
   },
   "devDependencies": {
+    "@types/node": "20.10.4",
     "@babel/core": "7.23.5",
     "@babel/preset-env": "7.23.5",
     "@rollup/plugin-babel": "6.0.4",
@@ -46,6 +49,7 @@
     "fs-extra": "11.2.0",
     "find-process": "1.4.7",
     "mocha": "10.2.0",
-    "rollup": "4.6.1"
+    "rollup": "4.6.1",
+    "typescript": "5.3.3"
   }
 }

--- a/src/Pool.js
+++ b/src/Pool.js
@@ -1,4 +1,4 @@
-var Promise = require('./Promise');
+var {Promise} = require('./Promise');
 var WorkerHandler = require('./WorkerHandler');
 var environment = require('./environment');
 var DebugPortAllocator = require('./debug-port-allocator');

--- a/src/Pool.js
+++ b/src/Pool.js
@@ -214,7 +214,7 @@ Pool.prototype.map = function (array, callback) {
 /**
  * Grab the first task from the queue, find a free worker, and assign the
  * worker to the task.
- * @protected
+ * @private
  */
 Pool.prototype._next = function () {
   if (this.tasks.length > 0) {
@@ -288,7 +288,7 @@ Pool.prototype._getWorker = function() {
  * pool size is met.
  * @param {WorkerHandler} worker
  * @return {Promise<WorkerHandler>}
- * @protected
+ * @private
  */
 Pool.prototype._removeWorker = function(worker) {
   var me = this;
@@ -319,7 +319,7 @@ Pool.prototype._removeWorker = function(worker) {
 /**
  * Remove a worker from the pool list.
  * @param {WorkerHandler} worker
- * @protected
+ * @private
  */
 Pool.prototype._removeWorkerFromList = function(worker) {
   // remove from the list with workers
@@ -394,7 +394,7 @@ Pool.prototype.stats = function () {
 
 /**
  * Ensures that a minimum of minWorkers is up and running
- * @protected
+ * @private
  */
 Pool.prototype._ensureMinWorkers = function() {
   if (this.minWorkers) {

--- a/src/Pool.js
+++ b/src/Pool.js
@@ -4,7 +4,8 @@ var environment = require('./environment');
 var DebugPortAllocator = require('./debug-port-allocator');
 var DEBUG_PORT_ALLOCATOR = new DebugPortAllocator();
 /**
- * A pool to manage workers
+ * A pool to manage workers, which can be created using the function workerpool.pool.
+ *
  * @param {String} [script]   Optional worker script
  * @param {import('./types.js').WorkerPoolOptions} [options]  See docs
  * @constructor

--- a/src/Pool.js
+++ b/src/Pool.js
@@ -113,7 +113,7 @@ function Pool(script, options) {
  *                                    If `method` is a Function, the function
  *                                    will be stringified and executed via the
  *                                    workers built-in function `run(fn, args)`.
- * @param {Parameters<T>} [params]  Function arguments applied when calling the function
+ * @param {Parameters<T> | null} [params]  Function arguments applied when calling the function
  * @param {import('./types.js').ExecOptions} [options]  Options
  * @return {Promise<ReturnType<T>>}
  */

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -214,7 +214,7 @@ Promise.prototype.always = function (fn) {
  * Create a promise which resolves when all provided promises are resolved,
  * and fails when any of the promises resolves.
  * @param {Promise[]} promises
- * @returns {Promise} promise
+ * @returns {Promise<any[], any>} promise
  */
 Promise.all = function (promises){
   return new Promise(function (resolve, reject) {

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -52,7 +52,7 @@ function Promise(handler, parent) {
   /**
    * Add an onSuccess callback and optionally an onFail callback to the Promise
    * @template TT
-   * @template TE
+   * @template [TE=never]
    * @param {(r: T) => TT} onSuccess
    * @param {(r: E) => TE} [onFail]
    * @returns {Promise<TT | TE, any>} promise

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -4,7 +4,8 @@
  * Promise
  *
  * Inspired by https://gist.github.com/RubaXa/8501359 from RubaXa <trash@rubaxa.org>
- *
+ * @template T
+ * @template E
  * @param {Function} handler   Called as handler(resolve: Function, reject: Function)
  * @param {Promise} [parent]   Parent promise for propagation of cancel and timeout
  */
@@ -23,8 +24,17 @@ function Promise(handler, parent) {
   var _onFail = [];
 
   // status
+  /**
+   * @readonly
+   */
   this.resolved = false;
+  /**
+   * @readonly
+   */
   this.rejected = false;
+  /**
+   * @readonly
+   */
   this.pending = true;
 
   /**
@@ -41,9 +51,11 @@ function Promise(handler, parent) {
 
   /**
    * Add an onSuccess callback and optionally an onFail callback to the Promise
-   * @param {Function} onSuccess
-   * @param {Function} [onFail]
-   * @returns {Promise} promise
+   * @template TT
+   * @template TE
+   * @param {(r: T) => TT} onSuccess
+   * @param {(r: E) => TE} [onFail]
+   * @returns {Promise<TT | TE, any>} promise
    */
   this.then = function (onSuccess, onFail) {
     return new Promise(function (resolve, reject) {
@@ -104,7 +116,7 @@ function Promise(handler, parent) {
 
   /**
    * Cancel te promise. This will reject the promise with a CancellationError
-   * @returns {Promise} self
+   * @returns {this} self
    */
   this.cancel = function () {
     if (parent) {
@@ -122,7 +134,7 @@ function Promise(handler, parent) {
    * the time, the promise will be cancelled and a TimeoutError is thrown.
    * If the promise is resolved in time, the timeout is removed.
    * @param {number} delay     Delay in milliseconds
-   * @returns {Promise} self
+   * @returns {this} self
    */
   this.timeout = function (delay) {
     if (parent) {
@@ -177,8 +189,9 @@ function _then(callback, resolve, reject) {
 
 /**
  * Add an onFail callback to the Promise
- * @param {Function} onFail
- * @returns {Promise} promise
+ * @template TT
+ * @param {(error: E) => TT} onFail
+ * @returns {Promise<T | TT>} promise
  */
 Promise.prototype['catch'] = function (onFail) {
   return this.then(null, onFail);
@@ -189,8 +202,9 @@ Promise.prototype['catch'] = function (onFail) {
 
 /**
  * Execute given callback when the promise either resolves or rejects.
- * @param {Function} fn
- * @returns {Promise} promise
+ * @template TT
+ * @param {() => Promise<TT>} fn
+ * @returns {Promise<TT>} promise
  */
 Promise.prototype.always = function (fn) {
   return this.then(fn, fn);

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -5,7 +5,7 @@
  *
  * Inspired by https://gist.github.com/RubaXa/8501359 from RubaXa <trash@rubaxa.org>
  * @template T
- * @template E
+ * @template [E=Error]
  * @param {Function} handler   Called as handler(resolve: Function, reject: Function)
  * @param {Promise} [parent]   Parent promise for propagation of cancel and timeout
  */
@@ -290,4 +290,4 @@ TimeoutError.prototype.name = 'TimeoutError';
 Promise.TimeoutError = TimeoutError;
 
 
-module.exports = Promise;
+exports.Promise = Promise;

--- a/src/WorkerHandler.js
+++ b/src/WorkerHandler.js
@@ -206,7 +206,7 @@ function objectToError (obj) {
  * on node.js or a WebWorker in a browser environment.
  * @param {String} [script] If no script is provided, a default worker with a
  *                          function run will be created.
- * @param {WorkerPoolOptions} _options See docs
+ * @param {import('./types.js').WorkerPoolOptions} [_options] See docs
  * @constructor
  */
 function WorkerHandler(script, _options) {
@@ -328,7 +328,7 @@ WorkerHandler.prototype.methods = function () {
  * @param {String} method
  * @param {Array} [params]
  * @param {{resolve: Function, reject: Function}} [resolver]
- * @param {ExecOptions}  [options]
+ * @param {import('./types.js').ExecOptions}  [options]
  * @return {Promise.<*, Error>} result
  */
 WorkerHandler.prototype.exec = function(method, params, resolver, options) {

--- a/src/WorkerHandler.js
+++ b/src/WorkerHandler.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Promise = require('./Promise');
+var {Promise} = require('./Promise');
 var environment = require('./environment');
 const {validateOptions, forkOptsNames, workerThreadOptsNames, workerOptsNames} = require("./validateOptions");
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,48 +1,43 @@
-var environment = require('./environment');
+const {platform, isMainThread, cpus} = require('./environment');
 
 /**
  * Create a new worker pool
  * @param {string} [script]
- * @param {WorkerPoolOptions} [options]
+ * @param {import("./types.js").WorkerPoolOptions} [options]
  * @returns {Pool} pool
  */
-exports.pool = function pool(script, options) {
+function pool(script, options) {
   var Pool = require('./Pool');
 
   return new Pool(script, options);
 };
+exports.pool = pool;
 
 /**
  * Create a worker and optionally register a set of methods to the worker.
- * @param {Object} [methods]
- * @param {WorkerRegisterOptions} [options]
+ * @param {{ [k: string]: (...args: any[]) => any }} [methods]
+ * @param {import("./types.js").WorkerRegisterOptions} [options]
  */
-exports.worker = function worker(methods, options) {
+function worker(methods, options) {
   var worker = require('./worker');
   worker.add(methods, options);
 };
+exports.worker = worker;
 
 /**
  * Sends an event to the parent worker pool.
  * @param {any} payload 
  */
-exports.workerEmit = function workerEmit(payload) {
+function workerEmit(payload) {
   var worker = require('./worker');
   worker.emit(payload);
 };
+exports.workerEmit = workerEmit;
 
-/**
- * Create a promise.
- * @type {Promise} promise
- */
 exports.Promise = require('./Promise');
 
-/**
- * Create a transfer object.
- * @type {Transfer} transfer
- */
 exports.Transfer = require('./transfer');
 
-exports.platform = environment.platform;
-exports.isMainThread = environment.isMainThread;
-exports.cpus = environment.cpus;
+exports.platform = platform;
+exports.isMainThread = isMainThread;
+exports.cpus = cpus;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,13 @@
 const {platform, isMainThread, cpus} = require('./environment');
 
 /**
+ * @overload
+ * Create a new worker pool
+ * @param {import("./types.js").WorkerPoolOptions} [script]
+ * @returns {Pool} pool
+ */
+/**
+ * @overload
  * Create a new worker pool
  * @param {string} [script]
  * @param {import("./types.js").WorkerPoolOptions} [options]

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,8 @@ function workerEmit(payload) {
 };
 exports.workerEmit = workerEmit;
 
-exports.Promise = require('./Promise');
+const {Promise} = require('./Promise');
+exports.Promise = Promise;
 
 exports.Transfer = require('./transfer');
 

--- a/src/types.js
+++ b/src/types.js
@@ -29,7 +29,7 @@
  * @property {Object} [forkOpts] For `process` worker type. An object passed as `options` to [child_process.fork](https://nodejs.org/api/child_process.html#child_processforkmodulepath-args-options).
  * @property {WorkerOptions} [workerOpts] For `web` worker type. An object passed to the [constructor of the web worker](https://html.spec.whatwg.org/multipage/workers.html#dom-worker). See [WorkerOptions specification](https://html.spec.whatwg.org/multipage/workers.html#workeroptions) for available options. 
  * @property {Object} [workerThreadOpts] Object`. For `worker` worker type. An object passed to [worker_threads.options](https://nodejs.org/api/worker_threads.html#new-workerfilename-options).
- * @property { (arg: WorkerArg) => WorkerArg | undefined } [onCreateWorker] A callback that is called whenever a worker is being created. It can be used to allocate resources for each worker for example. Optionally, this callback can return an object containing one or more of the `CreateWorkerArg` properties. The provided properties will be used to override the Pool properties for the worker being created.
+ * @property { (arg: WorkerArg) => WorkerArg | undefined } [onCreateWorker] A callback that is called whenever a worker is being created. It can be used to allocate resources for each worker for example. Optionally, this callback can return an object containing one or more of the `WorkerArg` properties. The provided properties will be used to override the Pool properties for the worker being created.
  * @property { (arg: WorkerArg) => void } [onTerminateWorker] A callback that is called whenever a worker is being terminated. It can be used to release resources that might have been allocated for this specific worker. The callback is passed as argument an object as described for `onCreateWorker`, with each property sets with the value for the worker being terminated.
  */
 
@@ -41,7 +41,7 @@
 
 /**
  * @typedef {Object} WorkerRegisterOptions
- * @property {(code: number | undefined) => Promise<void> | void} [onTerminate] A callback that is called whenever a worker is being terminated. It can be used to release resources that might have been allocated for this specific worker. The difference with pool's `onTerminateWorker` is that this callback runs in the worker context, while onTerminateWorker is executed on the main thread.
+ * @property {(code: number | undefined) => PromiseLike<void> | void} [onTerminate] A callback that is called whenever a worker is being terminated. It can be used to release resources that might have been allocated for this specific worker. The difference with pool's `onTerminateWorker` is that this callback runs in the worker context, while onTerminateWorker is executed on the main thread.
  */
 
 /**

--- a/src/types.js
+++ b/src/types.js
@@ -6,26 +6,47 @@
  */
 
 /**
+ * @typedef {Object} WorkerArg
+ * @property {string[]} [forkArgs] The `forkArgs` option of this pool
+ * @property {Object} [forkOpts] The `forkOpts` option of this pool
+ * @property {WorkerOptions} [workerOpts] The `workerOpts` option of this pool
+ * @property {Object} [workerThreadOpts] The `workerThreadOpts` option of this pool
+ * @property {string} [script] The `script` option of this pool
+ */
+
+/**
  * @typedef {Object} WorkerPoolOptions
- * @property {number | 'max'} [minWorkers]
- * @property {number} [maxWorkers]
- * @property {number} [maxQueueSize]
+ * @property {number | 'max'} [minWorkers] The minimum number of workers that must be initialized and kept available. Setting this to `'max'` will create `maxWorkers` default workers
+ * @property {number} [maxWorkers]  The default number of maxWorkers is the number of CPU's minus one. When the number of CPU's could not be determined (for example in older browsers), `maxWorkers` is set to 3.
+ * @property {number} [maxQueueSize] The maximum number of tasks allowed to be queued. Can be used to prevent running out of memory. If the maximum is exceeded, adding a new task will throw an error. The default value is `Infinity`.
  * @property {'auto' | 'web' | 'process' | 'thread'} [workerType]
- * @property {number} [workerTerminateTimeout]
- * @property {*} [forkArgs]
- * @property {*} [forkOpts]
- * @property {WorkerOptions} [workerOpts]
- * @property {Function} [onCreateWorker]
- * @property {Function} [onTerminateWorker]
+ *   - In case of `'auto'` (default), workerpool will automatically pick a suitable type of worker: when in a browser environment, `'web'` will be used. When in a node.js environment, `worker_threads` will be used if available (Node.js >= 11.7.0), else `child_process` will be used.
+ *   - In case of `'web'`, a Web Worker will be used. Only available in a browser environment.
+ *   - In case of `'process'`, `child_process` will be used. Only available in a node.js environment.
+ *   - In case of `'thread'`, `worker_threads` will be used. If `worker_threads` are not available, an error is thrown. Only available in a node.js environment.
+ * @property {number} [workerTerminateTimeout] The timeout in milliseconds to wait for a worker to cleanup it's resources on termination before stopping it forcefully. Default value is `1000`.
+ * @property {string[]} [forkArgs] For `process` worker type. An array passed as `args` to [child_process.fork](https://nodejs.org/api/child_process.html#child_processforkmodulepath-args-options)
+ * @property {Object} [forkOpts] For `process` worker type. An object passed as `options` to [child_process.fork](https://nodejs.org/api/child_process.html#child_processforkmodulepath-args-options).
+ * @property {WorkerOptions} [workerOpts] For `web` worker type. An object passed to the [constructor of the web worker](https://html.spec.whatwg.org/multipage/workers.html#dom-worker). See [WorkerOptions specification](https://html.spec.whatwg.org/multipage/workers.html#workeroptions) for available options. 
+ * @property {Object} [workerThreadOpts] Object`. For `worker` worker type. An object passed to [worker_threads.options](https://nodejs.org/api/worker_threads.html#new-workerfilename-options).
+ * @property { (arg: WorkerArg) => WorkerArg | undefined } [onCreateWorker] A callback that is called whenever a worker is being created. It can be used to allocate resources for each worker for example. Optionally, this callback can return an object containing one or more of the `CreateWorkerArg` properties. The provided properties will be used to override the Pool properties for the worker being created.
+ * @property { (arg: WorkerArg) => void } [onTerminateWorker] A callback that is called whenever a worker is being terminated. It can be used to release resources that might have been allocated for this specific worker. The callback is passed as argument an object as described for `onCreateWorker`, with each property sets with the value for the worker being terminated.
  */
 
 /**
  * @typedef {Object} ExecOptions
- * @property {(payload: any) => unknown} [on]
- * @property {Object[]} [transfer]
+ * @property {(payload: any) => unknown} [on] An event listener, to handle events sent by the worker for this execution.
+ * @property {Object[]} [transfer] A list of transferable objects to send to the worker. Not supported by `process` worker type. See ./examples/transferableObjects.js for usage.
  */
 
 /**
  * @typedef {Object} WorkerRegisterOptions
- * @property {(code: number | undefined) => Promise | void} [onTerminate]
+ * @property {(code: number | undefined) => Promise<void> | void} [onTerminate] A callback that is called whenever a worker is being terminated. It can be used to release resources that might have been allocated for this specific worker. The difference with pool's `onTerminateWorker` is that this callback runs in the worker context, while onTerminateWorker is executed on the main thread.
  */
+
+/**
+ * @template { { [k: string]: (...args: any[]) => any } } T
+ * @typedef {{ [M in keyof T]: (...args: Parameters<T[M]>) => Promise<ReturnType<T[M]>>; }} Proxy<T>
+ */
+
+module.exports = {}

--- a/src/types.js
+++ b/src/types.js
@@ -1,16 +1,9 @@
 /**
- * @typedef {Object} WorkerOptions
- * @property {'classic' | 'module'} [type]
- * @property {'omit' | 'same-origin' | 'include'} [credentials]
- * @property {string} [name]
- */
-
-/**
  * @typedef {Object} WorkerArg
  * @property {string[]} [forkArgs] The `forkArgs` option of this pool
- * @property {Object} [forkOpts] The `forkOpts` option of this pool
+ * @property {import('child_process').ForkOptions} [forkOpts] The `forkOpts` option of this pool
  * @property {WorkerOptions} [workerOpts] The `workerOpts` option of this pool
- * @property {Object} [workerThreadOpts] The `workerThreadOpts` option of this pool
+ * @property {import('worker_threads').WorkerOptions} [workerThreadOpts] The `workerThreadOpts` option of this pool
  * @property {string} [script] The `script` option of this pool
  */
 
@@ -26,9 +19,9 @@
  *   - In case of `'thread'`, `worker_threads` will be used. If `worker_threads` are not available, an error is thrown. Only available in a node.js environment.
  * @property {number} [workerTerminateTimeout] The timeout in milliseconds to wait for a worker to cleanup it's resources on termination before stopping it forcefully. Default value is `1000`.
  * @property {string[]} [forkArgs] For `process` worker type. An array passed as `args` to [child_process.fork](https://nodejs.org/api/child_process.html#child_processforkmodulepath-args-options)
- * @property {Object} [forkOpts] For `process` worker type. An object passed as `options` to [child_process.fork](https://nodejs.org/api/child_process.html#child_processforkmodulepath-args-options).
+ * @property {import('child_process').ForkOptions} [forkOpts] For `process` worker type. An object passed as `options` to [child_process.fork](https://nodejs.org/api/child_process.html#child_processforkmodulepath-args-options).
  * @property {WorkerOptions} [workerOpts] For `web` worker type. An object passed to the [constructor of the web worker](https://html.spec.whatwg.org/multipage/workers.html#dom-worker). See [WorkerOptions specification](https://html.spec.whatwg.org/multipage/workers.html#workeroptions) for available options. 
- * @property {Object} [workerThreadOpts] Object`. For `worker` worker type. An object passed to [worker_threads.options](https://nodejs.org/api/worker_threads.html#new-workerfilename-options).
+ * @property {import('worker_threads').WorkerOptions} [workerThreadOpts] Object`. For `worker` worker type. An object passed to [worker_threads.options](https://nodejs.org/api/worker_threads.html#new-workerfilename-options).
  * @property { (arg: WorkerArg) => WorkerArg | undefined } [onCreateWorker] A callback that is called whenever a worker is being created. It can be used to allocate resources for each worker for example. Optionally, this callback can return an object containing one or more of the `WorkerArg` properties. The provided properties will be used to override the Pool properties for the worker being created.
  * @property { (arg: WorkerArg) => void } [onTerminateWorker] A callback that is called whenever a worker is being terminated. It can be used to release resources that might have been allocated for this specific worker. The callback is passed as argument an object as described for `onCreateWorker`, with each property sets with the value for the worker being terminated.
  */

--- a/src/worker.js
+++ b/src/worker.js
@@ -212,7 +212,7 @@ worker.on('message', function (request) {
 /**
  * Register methods to the worker
  * @param {Object} [methods]
- * @param {WorkerRegisterOptions} [options]
+ * @param {import('./types.js').WorkerRegisterOptions} [options]
  */
 worker.register = function (methods, options) {
 

--- a/test/Pool.test.js
+++ b/test/Pool.test.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var Promise = require('../src/Promise');
+var {Promise} = require('../src/Promise');
 var Pool = require('../src/Pool');
 var tryRequire = require('./utils').tryRequire
 

--- a/test/Promise.test.js
+++ b/test/Promise.test.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var Promise = require('../src/Promise');
+var {Promise} = require('../src/Promise');
 
 describe ('Promise', function () {
 

--- a/test/WorkerHandler.test.js
+++ b/test/WorkerHandler.test.js
@@ -1,10 +1,10 @@
 var assert = require('assert');
-var Promise = require('../src/Promise');
+var {Promise} = require('../src/Promise');
 var WorkerHandler = require('../src/WorkerHandler');
 var path = require('path');
 var childProcess = require('child_process');
 var findProcess = require('find-process');
-const { CancellationError } = require('../src/Promise');
+const { CancellationError } = Promise;
 
 function add(a, b) {
   return a + b;

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "ES2020", "DOM"
+    ],
+    "target": "ES2020",
+    "allowJs": true,
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "noEmit": true,
+  },
+  "files": [
+    "./workerpool-tests.ts"
+  ]
+}

--- a/test/types/workerpool-tests.ts
+++ b/test/types/workerpool-tests.ts
@@ -96,8 +96,6 @@ pool.proxy().then(proxy => {
 new wp.Promise.CancellationError();
 new wp.Promise.TimeoutError();
 
-// We can remove the following line when migrating to ESM.
-// @ts-expect-error
 let promises: wp.Promise<any[]> = wp.Promise.all([
     pool.exec("foo", null),
     pool.exec("foo", null),

--- a/test/types/workerpool-tests.ts
+++ b/test/types/workerpool-tests.ts
@@ -96,7 +96,9 @@ pool.proxy().then(proxy => {
 new wp.Promise.CancellationError();
 new wp.Promise.TimeoutError();
 
-let promises = wp.Promise.all([
+// We can remove the following line when migrating to ESM.
+// @ts-expect-error
+let promises: wp.Promise<any[]> = wp.Promise.all([
     pool.exec("foo", null),
     pool.exec("foo", null),
     pool.exec("foo", null),

--- a/test/types/workerpool-tests.ts
+++ b/test/types/workerpool-tests.ts
@@ -1,0 +1,114 @@
+/**
+
+The MIT License (MIT)
+
+Copyrights    Alorel, Seulgi Kim, Emily M Klassen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/workerpool/workerpool-tests.ts
+
+ */
+import * as wp from "../../types/";
+
+wp.pool("foo");
+wp.pool({ minWorkers: 1 });
+wp.pool({ minWorkers: "max" });
+wp.pool({ minWorkers: "max", maxWorkers: 1 });
+wp.pool({ minWorkers: 1, maxWorkers: 1 });
+wp.pool({ maxWorkers: 1 });
+wp.pool({ maxQueueSize: 5 });
+wp.pool({ workerType: "process" });
+wp.pool({ workerType: "thread" });
+wp.pool({ workerType: "web" });
+wp.pool({ workerType: "auto" });
+wp.pool({ workerTerminateTimeout: 50 });
+wp.pool({ forkArgs: ["foo", "bar"] });
+wp.pool({ forkOpts: { cwd: "/tmp" } });
+wp.pool({ workerThreadOpts: { workerData: { foo: "bar" } } });
+wp.pool({
+    onCreateWorker: ({ forkArgs, forkOpts, script, workerThreadOpts }) => ({
+        forkArgs,
+        forkOpts,
+        script,
+        workerThreadOpts,
+    }),
+});
+wp.pool({
+    onTerminateWorker: ({ forkArgs, forkOpts, script, workerThreadOpts }) => ({
+        forkArgs,
+        forkOpts,
+        script,
+        workerThreadOpts,
+    }),
+});
+const pool = wp.pool();
+pool.terminate()
+    .then(() => pool.terminate())
+    .then(() => pool.terminate())
+    .then(() => pool.terminate(true))
+    .then(() => pool.terminate(false))
+    .then(() => pool.terminate(true))
+    .then(() => pool.terminate(false))
+    .then(() => pool.terminate(false, 1000));
+
+let x: number = pool.stats().activeTasks;
+x = pool.stats().busyWorkers;
+x = pool.stats().idleWorkers;
+x = pool.stats().pendingTasks;
+x = pool.stats().totalWorkers;
+
+pool.terminate().then(() => {});
+pool.proxy().then(() => {});
+pool.exec("foo", null)
+    .then(() => pool.exec("foo", []))
+    .then(() => pool.exec(() => {}, null));
+
+function add(a: number, b: number): number {
+    wp.workerEmit({ status: "in_progress" });
+    return a + b;
+}
+
+function hello(): string {
+    return "hello";
+}
+
+pool.exec(add, [1, 2]).then((c: number) => c);
+pool.exec<typeof add>("add", [1, 2], { on: payload => console.log(payload) }).then((c: number) => c);
+pool.exec(hello, []).then((s: string) => s);
+
+const workers = { add, hello };
+type IWorkers = typeof workers;
+pool.proxy<IWorkers>().then(proxy => {
+    proxy.add(1, 2);
+    proxy.hello();
+});
+
+pool.proxy().then(proxy => {
+    proxy.add(1, 2);
+    proxy.hello();
+});
+
+new wp.Promise.CancellationError();
+new wp.Promise.TimeoutError();
+
+let promises = wp.Promise.all([
+    pool.exec("foo", null),
+    pool.exec("foo", null),
+    pool.exec("foo", null),
+]);
+promises = wp.Promise.all([]);
+
+const promiseLike: PromiseLike<any[]> = promises;
+
+wp.worker({ a: () => 1, b: () => 2 });
+wp.worker(undefined, { onTerminate: () => {} });
+wp.worker(undefined, { onTerminate: () => Promise.resolve() });
+wp.worker({ a: () => 1, b: () => 2 }, { onTerminate: () => {} });
+wp.worker(undefined, undefined);
+
+new wp.Transfer("foo", []);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "ES2020", "DOM"
+    ],
+    "target": "ES2020",
+    "allowJs": true,
+    "declaration": true,
+    "strict": true,
+    "emitDeclarationOnly": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "outDir": "./types"
+  },
+  "files": [
+    "src/index.js"
+  ]
+}


### PR DESCRIPTION
Generate types from JSDoc comments with TypeScript compiler. Close #334. 

TypeScript compiler can generate `.d.ts` files from JavaScript files. See

- https://www.typescriptlang.org/docs/handbook/declaration-files/dts-from-js.html

To make it work, we need minor modifications on `src/index.js` and `types.js`.

Run `npm run types` to generate types.
