### PR TITLE
Export more types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,20 @@
 const {platform, isMainThread, cpus} = require('./environment');
 
+/** @typedef {import("./Pool")} Pool */
+/** @typedef {import("./types.js").WorkerPoolOptions} WorkerPoolOptions */
+/** @typedef {import("./types.js").WorkerRegisterOptions} WorkerRegisterOptions */
+
 /**
  * @overload
  * Create a new worker pool
- * @param {import("./types.js").WorkerPoolOptions} [script]
+ * @param {WorkerPoolOptions} [script]
  * @returns {Pool} pool
  */
 /**
  * @overload
  * Create a new worker pool
  * @param {string} [script]
- * @param {import("./types.js").WorkerPoolOptions} [options]
+ * @param {WorkerPoolOptions} [options]
  * @returns {Pool} pool
  */
 function pool(script, options) {
@@ -23,7 +27,7 @@ exports.pool = pool;
 /**
  * Create a worker and optionally register a set of methods to the worker.
  * @param {{ [k: string]: (...args: any[]) => any }} [methods]
- * @param {import("./types.js").WorkerRegisterOptions} [options]
+ * @param {WorkerRegisterOptions} [options]
  */
 function worker(methods, options) {
   var worker = require('./worker');


### PR DESCRIPTION
This allows code using workerpool to easily reference pool types. For example, I could write code similar to the following in workerpool 8, but in workerpool 9, I could not find an easy way to access these types, since they're just imports within the generated `index.d.ts`.

```ts
import { pool, type WorkerPoolOptions, type WorkerPool } from 'workerpool';

function getOptions(): WorkerPoolOptions { /* ... */ };
function makeMyPool(): WorkerPool {
  const myPool = pool(getOptions());
  // initialize
  return myPool;
}
```

(workerpool 9's build-in types also rename `WorkerPool` to `Pool`, but that's an easy change to make in calling code.)