### PR TITLE
Improve the logic of isNode().

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -1,10 +1,12 @@
 
 // source: https://github.com/flexdinesh/browser-or-node
+// source: https://github.com/mozilla/pdf.js/blob/7ea0e40e588864cd938d1836ec61f1928d3877d3/src/shared/util.js#L24
 var isNode = function (nodeProcess) {
   return (
     typeof nodeProcess !== 'undefined' &&
     nodeProcess.versions != null &&
-    nodeProcess.versions.node != null
+    nodeProcess.versions.node != null &&
+    nodeProcess + '' === '[object process]'
   );
 }
 module.exports.isNode = isNode

--- a/test/environment.test.js
+++ b/test/environment.test.js
@@ -8,10 +8,11 @@ describe('Environment Detection', function () {
     assert.strictEqual(isNode(undefined), false)
     assert.strictEqual(isNode({}), false)
     assert.strictEqual(isNode({ versions: {} }), false)
+    assert.strictEqual(isNode({ versions: { node: '10.0.0' } }), false)
   })
 
   it('is platform assigned to be node', function () {
-    assert.strictEqual(isNode({ versions: { node: '10.0.0' } }), true)
+    assert.strictEqual(isNode(process), true)
   })
 })
 


### PR DESCRIPTION
Improve the logic of `isNode()`. Close #320.

The trick of `'[object process]'` seems to be widely used.

- https://github.com/search?q=%22%5Bobject+process%5D%22&type=code
- https://github.com/mozilla/pdf.js/blob/7ea0e40e588864cd938d1836ec61f1928d3877d3/src/shared/util.js#L24

Now, since the `process.versions` is empty on `jspm-core`, you could close the original issue without merging this PR.

- https://github.com/jspm/jspm-core/blob/7af7d7413f472305d08d0d78ec3d1f15588be50a/nodelibs/browser/process.js#L78