### PR TITLE
fix: pool.exec(<function>) fails to emit message event to the pool.

### DIFF
--- a/src/Pool.js
+++ b/src/Pool.js
@@ -166,7 +166,7 @@ Pool.prototype.exec = function (method, params, options) {
   }
   else if (typeof method === 'function') {
     // send stringified function and function arguments to worker
-    return this.exec('run', [String(method), params]);
+    return this.exec('run', [String(method), params], options);
   }
   else {
     throw new TypeError('Function or string expected as argument "method"');


### PR DESCRIPTION
When using worker-pool in a browser environment, worker function registration does not work. Only `pool.exec(<function>)` can be run, but does not handle the on message callbacks.

This fix proposes to send the `pool.exec` options to the execution script.

Referenced doc: https://github.com/josdejong/workerpool#events
Playground: https://codesandbox.io/p/sandbox/workerpool-in-a-react-project-forked-dgjxxc

Possible fix for issue #438 