### PR TITLE
Feat/std streams task abort

### DIFF
--- a/src/WorkerHandler.js
+++ b/src/WorkerHandler.js
@@ -435,7 +435,7 @@ WorkerHandler.prototype.exec = function(method, params, resolver, options) {
       me.tracking[id] = {
         id,
         resolver: Promise.defer(),
-        options: me.processing[id].options,
+        options: options,
       };
       
       // remove this task from the queue. It is already rejected (hence this

--- a/src/WorkerHandler.js
+++ b/src/WorkerHandler.js
@@ -301,6 +301,16 @@ function WorkerHandler(script, _options) {
             task.resolver.resolve(response.result);
           }
         }
+      }else {
+        // if the task is not the current, it might be tracked for cleanup
+        var task = me.tracking[id];
+        if (task !== undefined) {
+          if (response.isEvent) {
+            if (task.options && typeof task.options.on === 'function') {
+              task.options.on(response.payload);
+            }
+          }
+        } 
       }
 
       if (response.method === CLEANUP_METHOD_ID) {

--- a/src/WorkerHandler.js
+++ b/src/WorkerHandler.js
@@ -301,7 +301,7 @@ function WorkerHandler(script, _options) {
             task.resolver.resolve(response.result);
           }
         }
-      }else {
+      } else {
         // if the task is not the current, it might be tracked for cleanup
         var task = me.tracking[id];
         if (task !== undefined) {

--- a/src/WorkerHandler.js
+++ b/src/WorkerHandler.js
@@ -220,13 +220,15 @@ function objectToError (obj) {
 
 function handleEmittedStdPayload(handler, payload) {
   // TODO: refactor if parallel task execution gets added
-  if (Object.keys(handler.processing).length !== 1) {
-    return;
-  }
   var task = Object.values(handler.processing)[0]
-  if (task.options && typeof task.options.on === 'function') {
+  if (task && task.options && typeof task.options.on === 'function') {
     task.options.on(payload);
   }
+  
+  task = Object.values(handler.tracking)[0];
+  if (task && task.options && typeof task.options.on === "function") {
+    task.options.on(payload);
+  } 
 }
 
 /**
@@ -422,7 +424,8 @@ WorkerHandler.prototype.exec = function(method, params, resolver, options) {
     if (error instanceof Promise.CancellationError || error instanceof Promise.TimeoutError) {
       me.tracking[id] = {
         id,
-        resolver: Promise.defer()
+        resolver: Promise.defer(),
+        options: me.processing[id].options,
       };
       
       // remove this task from the queue. It is already rejected (hence this

--- a/src/WorkerHandler.js
+++ b/src/WorkerHandler.js
@@ -220,15 +220,11 @@ function objectToError (obj) {
 
 function handleEmittedStdPayload(handler, payload) {
   // TODO: refactor if parallel task execution gets added
-  var task = Object.values(handler.processing)[0]
-  if (task && task.options && typeof task.options.on === 'function') {
-    task.options.on(payload);
-  }
+  Object.values(handler.processing)
+    .forEach(task => task?.options?.on(payload));
   
-  task = Object.values(handler.tracking)[0];
-  if (task && task.options && typeof task.options.on === "function") {
-    task.options.on(payload);
-  } 
+  Object.values(handler.tracking)
+    .forEach(task => task?.options?.on(payload)); 
 }
 
 /**

--- a/test/Pool.test.js
+++ b/test/Pool.test.js
@@ -1571,7 +1571,6 @@ describe('Pool', function () {
       pool.exec('stdoutStreamOnAbort', [], {
         on: function (payload) {
           assert.strictEqual(payload.stdout.trim(), "Hello, world!");
-          console.log(payload);
           pool.terminate();
           done();
         }

--- a/test/Pool.test.js
+++ b/test/Pool.test.js
@@ -1574,7 +1574,7 @@ describe('Pool', function () {
           pool.terminate();
           done();
         }
-      }).timeout(100);
+      }).timeout(50);
     });
 
     it('should trigger event in abort handler', function (done) {
@@ -1591,7 +1591,7 @@ describe('Pool', function () {
           pool.terminate();
           done();
         }
-      }).timeout(100);
+      }).timeout(50);
     });
   });
 

--- a/test/Pool.test.js
+++ b/test/Pool.test.js
@@ -1354,7 +1354,7 @@ describe('Pool', function () {
         maxWorkers: 1,
         onCreateWorker: () => {
           workerCount += 1;
-        }
+        },
       });
       
       let task = pool.exec('asyncTimeout', [],  {});
@@ -1558,6 +1558,25 @@ describe('Pool', function () {
           });
         });
       });
+    });
+
+    it('should trigger event stdout in abort handler', function (done) {
+      var pool = createPool(__dirname + '/workers/cleanup-abort.js', {
+        maxWorkers: 1,
+        workerType: 'process',
+        emitStdStreams: true, 
+        workerTerminateTimeout: 1000,
+      });
+
+      pool.exec('stdoutStreamOnAbort', [], {
+        on: function (payload) {
+          assert.strictEqual(payload.stdout.trim(), "Hello, world!");
+          console.log(payload);
+          pool.terminate();
+          done();
+        }
+      }).timeout(100);
+
     });
   });
 

--- a/test/Pool.test.js
+++ b/test/Pool.test.js
@@ -1575,7 +1575,23 @@ describe('Pool', function () {
           done();
         }
       }).timeout(100);
+    });
 
+    it('should trigger event in abort handler', function (done) {
+      var pool = createPool(__dirname + '/workers/cleanup-abort.js', {
+        maxWorkers: 1,
+        workerType: 'process',
+        emitStdStreams: true, 
+        workerTerminateTimeout: 1000,
+      });
+
+      pool.exec('eventEmitOnAbort', [], {
+        on: function (payload) {
+          assert.strictEqual(payload.status, 'cleanup_success');
+          pool.terminate();
+          done();
+        }
+      }).timeout(100);
     });
   });
 

--- a/test/workers/cleanup-abort.js
+++ b/test/workers/cleanup-abort.js
@@ -5,8 +5,7 @@ function asyncTimeout() {
   return new Promise(function (resolve) {
     let timeout = setTimeout(() => {
         resolve();
-    }, 5000); 
-
+    }, 5000);
     me.worker.addAbortListener(async function () {
         clearTimeout(timeout);
         resolve();
@@ -34,11 +33,26 @@ function asyncAbortHandlerNeverResolves() {
   });
 }
 
+function stdoutStreamOnAbort() {
+  var me = this;
+  return new Promise(function (resolve) {
+    let timeout = setTimeout(() => {
+      resolve();
+    }, 5000); 
+  
+    me.worker.addAbortListener(async function () {
+        console.log("Hello, world!");
+        resolve();
+    });
+  });
+}
+
 // create a worker and register public functions
 workerpool.worker(
   {
     asyncTimeout: asyncTimeout,
     asyncAbortHandlerNeverResolves: asyncAbortHandlerNeverResolves,
+    stdoutStreamOnAbort: stdoutStreamOnAbort,
   },
   {
     abortListenerTimeout: 1000

--- a/test/workers/cleanup-abort.js
+++ b/test/workers/cleanup-abort.js
@@ -36,10 +36,6 @@ function asyncAbortHandlerNeverResolves() {
 function stdoutStreamOnAbort() {
   var me = this;
   return new Promise(function (resolve) {
-    let timeout = setTimeout(() => {
-      resolve();
-    }, 5000); 
-  
     me.worker.addAbortListener(async function () {
         console.log("Hello, world!");
         resolve();
@@ -47,12 +43,26 @@ function stdoutStreamOnAbort() {
   });
 }
 
+function eventEmitOnAbort() {
+  var me = this;
+  return new Promise(function (resolve) {
+    me.worker.addAbortListener(async function () {
+        workerpool.workerEmit({
+          status: 'cleanup_success',
+        });
+        resolve();
+    });
+  });
+}
+
+
 // create a worker and register public functions
 workerpool.worker(
   {
     asyncTimeout: asyncTimeout,
     asyncAbortHandlerNeverResolves: asyncAbortHandlerNeverResolves,
     stdoutStreamOnAbort: stdoutStreamOnAbort,
+    eventEmitOnAbort: eventEmitOnAbort,
   },
   {
     abortListenerTimeout: 1000


### PR DESCRIPTION
Adds support for events and std streams to parents from an abort handler.

example: 

```js
//worker
function eventEmitOnAbort() {
  var me = this;
  return new Promise(function (resolve) {
    me.worker.addAbortListener(async function () {
        workerpool.workerEmit({
          status: 'cleanup_success',
        });
        console.log("event sent to main thread");
        resolve();
    });
  });
}

workerpool.worker(
  {
    eventEmitOnAbort: eventEmitOnAbort,
  },
  {
    abortListenerTimeout: 1000
  }
);

// main thread
pool.exec('eventEmitOnAbort', [], {
  on: function (payload) {
      console.log("[Worker]", payload);
  }
}).timeout(50);
```

