### PR TITLE
fix: :bug: process.exitCode instead of calling process.exit to allow cleanup

### DIFF
--- a/test/Pool.test.js
+++ b/test/Pool.test.js
@@ -950,7 +950,7 @@ describe('Pool', function () {
 
     assert.strictEqual(pool.workers.length, 1);
 
-    return pool.terminate(false, 1000)
+    return pool.terminate(false, 2000)
       .then(function() {
         assert.strictEqual(pool.workers.length, 0);
       });


### PR DESCRIPTION
closes https://github.com/josdejong/workerpool/issues/429

see https://github.com/josdejong/workerpool/issues/429

The test sometimes failed, i guess because it now takes a bit longer to finish code and exit. after using 2000 it never failed on my machine. Hope thats ok.