### PR TITLE
Improve compatibility with standard Promise type

### DIFF
--- a/src/Promise.js
+++ b/src/Promise.js
@@ -36,6 +36,10 @@ function Promise(handler, parent) {
    * @readonly
    */
   this.pending = true;
+  /**
+   * @readonly
+   */
+  this[Symbol.toStringTag] = 'Promise';
 
   /**
    * Process onSuccess and onFail callbacks: add them to the queue.
@@ -213,7 +217,7 @@ Promise.prototype.always = function (fn) {
 /**
   * Execute given callback when the promise either resolves or rejects.
   * Same semantics as Node's Promise.finally()
-  * @param {Function} fn
+  * @param {Function | null | undefined} [fn]
   * @returns {Promise} promise
   */
 Promise.prototype.finally = function (fn) {

--- a/test/Promise.test.js
+++ b/test/Promise.test.js
@@ -391,6 +391,15 @@ describe ('Promise', function () {
         done()
       }, 200)
     });
+
+    it('should allow null finally', function(done) {
+      new Promise((resolve) => resolve())
+        .finally(null)
+        .then((arg) => {
+          assert.strictEqual(arg, undefined)
+          done()
+        })
+    });
   });
 
   describe('status', function () {

--- a/test/types/workerpool-tests.ts
+++ b/test/types/workerpool-tests.ts
@@ -117,3 +117,5 @@ wp.worker({ a: () => 1, b: () => 2 }, { onTerminate: () => {} });
 wp.worker(undefined, undefined);
 
 new wp.Transfer("foo", []);
+
+const p: Promise<string> = pool.exec<() => string>('hello').then((a) => a);


### PR DESCRIPTION
To prevent errors such as the following:

```
  Call signature return types 'Promise<any, Error>' and 'Promise<T>' are incompatible.
    The types of 'then(...).catch(...).finally' are incompatible between these types.
      Type '(fn: Function) => Promise<any, Error>' is not assignable to type '(onfinally?: (() => void) | null | undefined) => Promise<TResult1 | TResult2 | TResult>'.
        Types of parameters 'fn' and 'onfinally' are incompatible.
          Type '(() => void) | null | undefined' is not assignable to type 'Function'.
            Type 'undefined' is not assignable to type 'Function'.ts(2322)
```

```
  Property '[Symbol.toStringTag]' is missing in type 'Promise<any, Error>' but required in type 'Promise<T>'.ts(2322)
  ```