### PR TITLE
Minimum fix for Abort Listener

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -235,11 +235,12 @@ worker.cleanup = function(requestId) {
   // - Reject if one or more handlers exceed the 'abortListenerTimeout' interval
   // - Reject if one or more handlers reject
   // Upon one of the above cases a message will be sent to the handler with the result of the handler execution
-  // which will either kill the worker if the result contains an error, or 
-  return Promise.all([
-    settlePromise,
-    timeoutPromise
-  ]).then(function() {
+  // which will either kill the worker if the result contains an error, or keep it in the pool if the result
+  // does not contain an error.
+  return new Promise(function(resolve, reject) {
+    settlePromise.then(resolve, reject);
+    timeoutPromise.then(resolve, reject);
+  }).then(function() {
     worker.send({
       id: requestId,
       method: CLEANUP_METHOD_ID,

--- a/test/Pool.test.js
+++ b/test/Pool.test.js
@@ -1495,10 +1495,16 @@ describe('Pool', function () {
         maxWorkers: 2,
         onCreateWorker: function() {
           workerCount += 1;
+        },
+        onTerminateWorker: function(_) {
+          // call done in the termination callback so we know
+          // the worker was terminated before the test resolves
+          assert.strictEqual(pool.stats().totalWorkers, 0);
+          done();
         }
       });
-    
-      return pool.exec('asyncAbortHandlerNeverResolves', [])
+
+      const _ = pool.exec('asyncAbortHandlerNeverResolves', [])
       .timeout(1000)
       .catch(function (err) {
         assert(err instanceof Promise.TimeoutError);
@@ -1528,12 +1534,18 @@ describe('Pool', function () {
         maxWorkers: 1,
         onCreateWorker: function() {
           workerCount += 1;
+        },
+        onTerminateWorker: function(_) {
+          // call done in the termination callback so we know
+          // the worker was terminated before the test resolves
+          assert.strictEqual(pool.stats().totalWorkers, 0);
+          done();
         }
       });
     
       const task = pool.exec('asyncAbortHandlerNeverResolves', [])
-      
-      return new Promise(function(resolve) {
+
+      const _ = new Promise(function(resolve) {
         setTimeout(function() {
           resolve();
         }, 50);


### PR DESCRIPTION
Implements the minimum fix needed for the `Abort Listeners` to properly execute within the worker context. The change now allows the abort listener callback to be respected for either cleaning up the worker on error, or letting it continue to be used within the pool. As discussed in https://github.com/josdejong/workerpool/pull/484#issuecomment-2962689032.

There are a few minor updates to the abort tests to confirm that the workers are terminated in scenarios where the abort listener is intended to clean up the worker. This helps to confirm the current implementation is performing cleanup as expected.