### PR TITLE
Implement queueStrategy option (FIFO / LIFO / custom)

### DIFF
--- a/src/Promise.js
+++ b/src/Promise.js
@@ -265,7 +265,7 @@ Promise.all = function (promises){
 
 /**
  * Create a promise resolver
- * @returns {{promise: Promise, resolve: Function, reject: Function}} resolver
+ * @returns {import('./types.js').Resolver} resolver
  */
 Promise.defer = function () {
   var resolver = {};

--- a/src/queues.js
+++ b/src/queues.js
@@ -1,0 +1,68 @@
+/**
+ * FIFO Queue implementation
+ * @constructor
+ * @implements {import('./types').TaskQueue}
+ */
+function FIFOQueue() {
+  this.tasks = [];
+}
+
+FIFOQueue.prototype.push = function (task) {
+  this.tasks.push(task);
+}
+
+FIFOQueue.prototype.pop = function() {
+  return this.tasks.shift();
+};
+
+FIFOQueue.prototype.size = function() {
+  return this.tasks.length;
+};
+
+FIFOQueue.prototype.contains = function(task) {
+  return this.tasks.includes(task);
+}
+
+FIFOQueue.prototype[Symbol.iterator] = function () {
+  return this.tasks[Symbol.iterator]();
+}
+
+
+FIFOQueue.prototype.clear = function() {
+  this.tasks.length = 0;
+}
+
+/**
+ * LIFO Queue implementation
+ * @constructor
+ * @implements {import('./types').TaskQueue}
+ */
+function LIFOQueue() {
+  this.tasks = [];
+}
+
+LIFOQueue.prototype.push = function(task) {
+  this.tasks.push(task);
+};
+
+LIFOQueue.prototype.pop = function() {
+  return this.tasks.pop();
+};
+
+LIFOQueue.prototype.size = function() {
+  return this.tasks.length;
+};
+
+LIFOQueue.prototype.contains = function(task) {
+  return this.tasks.includes(task);
+}
+
+LIFOQueue.prototype[Symbol.iterator] = function () {
+  return this.tasks[Symbol.iterator]();
+}
+
+LIFOQueue.prototype.clear = function() {
+  this.tasks.length = 0;
+}
+
+module.exports = { FIFOQueue, LIFOQueue };

--- a/src/types.js
+++ b/src/types.js
@@ -7,6 +7,34 @@
  * @property {string} [script] The `script` option of this pool
  */
 
+
+/**
+ * @typedef {Object} Resolver
+ * @property {Promise} promise - The promise object
+ * @property {Function} resolve - Function to resolve the promise
+ * @property {Function} reject - Function to reject the promise
+ */
+
+/**
+ * @typedef {Object} Task
+ * @property {string | Function} method - The method name or function to execute
+ * @property {any[]} [params] - Parameters to pass to the method
+ * @property {Resolver} resolver - Promise resolver for the task result
+ * @property {number | null} timeout - Timeout value for the task
+ * @property {ExecOptions} [options] - Execution options
+ */
+
+/**
+ * @interface
+ * @typedef {Object} TaskQueue
+ * @property {(task: Task) => void} push - Add a task to the queue
+ * @property {() => Task | undefined} pop - Remove and return the next task
+ * @property {() => number} size - Get the current queue size
+ * @property {(task: Task) => boolean} contains - Check if the task is in the queue
+ * @property {() => void} clear - Clear all tasks from the queue
+ * @property {() => Iterator<Task>} [Symbol.iterator] - An iterator to iterate over all tasks in the queue, ignoring the order of the tasks (optional)
+ */
+
 /**
  * @typedef {Object} WorkerPoolOptions
  * @property {number | 'max'} [minWorkers] The minimum number of workers that must be initialized and kept available. Setting this to `'max'` will create `maxWorkers` default workers
@@ -17,10 +45,14 @@
  *   - In case of `'web'`, a Web Worker will be used. Only available in a browser environment.
  *   - In case of `'process'`, `child_process` will be used. Only available in a node.js environment.
  *   - In case of `'thread'`, `worker_threads` will be used. If `worker_threads` are not available, an error is thrown. Only available in a node.js environment.
+ * @property {'fifo' | 'lifo' | TaskQueue} [queueStrategy] - Queue scheduling strategy
+ *  - In case of `'fifo'` (default), tasks are executed in the order they are added (first in, first out).
+ *  - In case of `'lifo'`, tasks are executed in reverse order (last in, first out).
+ *  - A custom queue object can be provided as well, as long as it implements the `TaskQueue` interface.
+ * @property {string} [script] The path to the worker script. By default, an internal worker script is used that can be used in combination with `pool.exec()`, `pool.proxy()` and `pool.worker()`. A custom worker script can be used to create a pool of workers that are initialized with a custom script. See the documentation for more information and examples.
  * @property {number} [workerTerminateTimeout] The timeout in milliseconds to wait for a worker to clean up it's resources on termination before stopping it forcefully. Default value is `1000`.
  * @property {string[]} [forkArgs] For `process` worker type. An array passed as `args` to [child_process.fork](https://nodejs.org/api/child_process.html#child_processforkmodulepath-args-options)
- * @property {import('child_process').ForkOptions} [forkOpts] For `process` worker type. An object passed as `options` to [child_process.fork](https://nodejs.org/api/child_process.html#child_processforkmodulepath-args-options).
- * @property {WorkerOptions} [workerOpts] For `web` worker type. An object passed to the [constructor of the web worker](https://html.spec.whatwg.org/multipage/workers.html#dom-worker). See [WorkerOptions specification](https://html.spec.whatwg.org/multipage/workers.html#workeroptions) for available options.
+ * @property {import('child_process').ForkOptions} [forkOpts] For `process` worker type. An object passed as `options` to [child_process.fork](https://nodejs.org/api/child_process.html#child_processforkmodulepath-args-options). * @property {WorkerOptions} [workerOpts] For `web` worker type. An object passed to the [constructor of the web worker](https://html.spec.whatwg.org/multipage/workers.html#dom-worker). See [WorkerOptions specification](https://html.spec.whatwg.org/multipage/workers.html#workeroptions) for available options.
  * @property {import('worker_threads').WorkerOptions} [workerThreadOpts] Object`. For `worker` worker type. An object passed to [worker_threads.options](https://nodejs.org/api/worker_threads.html#new-workerfilename-options).
  * @property {boolean} [emitStdStreams] Capture stdout and stderr from the worker and emit them via the `stdout` and `stderr` events. Not supported by the `web` worker type.
  * @property { (arg: WorkerArg) => WorkerArg | undefined } [onCreateWorker] A callback that is called whenever a worker is being created. It can be used to allocate resources for each worker for example. Optionally, this callback can return an object containing one or more of the `WorkerArg` properties. The provided properties will be used to override the Pool properties for the worker being created.

--- a/test/Pool.test.js
+++ b/test/Pool.test.js
@@ -344,19 +344,19 @@ describe('Pool', function () {
       return a + b;
     }
 
-    assert.strictEqual(pool.tasks.length, 0);
+    assert.strictEqual(pool.taskQueue.size(), 0);
     assert.strictEqual(pool.workers.length, 0);
 
     var task1 = pool.exec(add, [3, 4]);
     var task2 = pool.exec(add, [2, 3]);
 
-    assert.strictEqual(pool.tasks.length, 0);
+    assert.strictEqual(pool.taskQueue.size(), 0);
     assert.strictEqual(pool.workers.length, 2);
 
     var task3 = pool.exec(add, [5, 7]);
     var task4 = pool.exec(add, [1, 1]);
 
-    assert.strictEqual(pool.tasks.length, 2);
+    assert.strictEqual(pool.taskQueue.size(), 2);
     assert.strictEqual(pool.workers.length, 2);
 
     Promise.all([
@@ -367,7 +367,7 @@ describe('Pool', function () {
         ])
         .then(function (results) {
           assert.deepStrictEqual(results, [7, 5, 12, 2]);
-          assert.strictEqual(pool.tasks.length, 0);
+          assert.strictEqual(pool.taskQueue.size(), 0);
           assert.strictEqual(pool.workers.length, 2);
 
           pool.terminate();
@@ -583,7 +583,7 @@ describe('Pool', function () {
           assert.strictEqual(reachedTheEnd, true);
 
           assert.strictEqual(pool.workers.length, 1);
-          assert.strictEqual(pool.tasks.length, 0);
+          assert.strictEqual(pool.taskQueue.size(), 0);
 
           return pool.terminate();
         })
@@ -593,15 +593,15 @@ describe('Pool', function () {
         .catch(done);
 
     assert.strictEqual(pool.workers.length, 1);
-    assert.strictEqual(pool.tasks.length, 0);
+    assert.strictEqual(pool.taskQueue.size(), 0);
 
     var p2 = pool.exec(one); // will be queued
     assert.strictEqual(pool.workers.length, 1);
-    assert.strictEqual(pool.tasks.length, 1);
+    assert.strictEqual(pool.taskQueue.size(), 1);
 
     p2.cancel();            // cancel immediately
     assert.strictEqual(pool.workers.length, 1);
-    assert.strictEqual(pool.tasks.length, 1);
+    assert.strictEqual(pool.taskQueue.size(), 1);
 
     reachedTheEnd = true;
   });
@@ -651,17 +651,17 @@ describe('Pool', function () {
           oneDone = true;
 
           assert.strictEqual(pool.workers.length, 1);
-          assert.strictEqual(pool.tasks.length, 1);
+          assert.strictEqual(pool.taskQueue.size(), 1);
 
           checkDone();
         });
 
     assert.strictEqual(pool.workers.length, 1);
-    assert.strictEqual(pool.tasks.length, 0);
+    assert.strictEqual(pool.taskQueue.size(), 0);
 
     var p2 = pool.exec(one); // will be queued
     assert.strictEqual(pool.workers.length, 1);
-    assert.strictEqual(pool.tasks.length, 1);
+    assert.strictEqual(pool.taskQueue.size(), 1);
 
     var p3 = pool.exec(two)
         .then(function (result) {
@@ -671,14 +671,14 @@ describe('Pool', function () {
           twoDone = true;
 
           assert.strictEqual(pool.workers.length, 1);
-          assert.strictEqual(pool.tasks.length, 0);
+          assert.strictEqual(pool.taskQueue.size(), 0);
 
           checkDone();
         });
 
     p2.cancel();            // cancel immediately
     assert.strictEqual(pool.workers.length, 1);
-    assert.strictEqual(pool.tasks.length, 2);
+    assert.strictEqual(pool.taskQueue.size(), 2);
 
     reachedTheEnd = true;
   });
@@ -843,7 +843,7 @@ describe('Pool', function () {
 
       assert.strictEqual(pool.maxWorkers, 2);
       assert.strictEqual(pool.workers.length, 2);
-      assert.strictEqual(pool.tasks.length, 3);
+      assert.strictEqual(pool.taskQueue.size(), 3);
 
       return Promise.all(tasks).then(function () {
         return pool.terminate();
@@ -896,10 +896,180 @@ describe('Pool', function () {
       assert.strictEqual(pool.minWorkers, count);
       assert.strictEqual(pool.maxWorkers, count);
       assert.strictEqual(pool.workers.length, count);
-      assert.strictEqual(pool.tasks.length, tasksCount - count);
+      assert.strictEqual(pool.taskQueue.size(), tasksCount - count);
 
       return Promise.all(tasks).then(function () {
         return pool.terminate();
+      });
+    });
+
+    describe('queueStrategy', function () {
+      it('should use FIFO queue strategy by default', function () {
+        var pool = createPool();
+
+        // Verify the queue type by checking behavior
+        assert.strictEqual(pool.taskQueue.constructor.name, 'FIFOQueue');
+
+        return pool.terminate();
+      });
+
+      it('should use FIFO queue strategy when explicitly specified', function () {
+        var pool = createPool({queueStrategy: 'fifo'});
+
+        assert.strictEqual(pool.taskQueue.constructor.name, 'FIFOQueue');
+
+        return pool.terminate();
+      });
+
+      it('should use LIFO queue strategy when specified', function () {
+        var pool = createPool({queueStrategy: 'lifo'});
+
+        assert.strictEqual(pool.taskQueue.constructor.name, 'LIFOQueue');
+
+        return pool.terminate();
+      });
+
+      it('should process tasks in FIFO order with fifo strategy', function () {
+        var pool = createPool({maxWorkers: 1, queueStrategy: 'fifo'});
+        var results = [];
+
+        function delayedAdd(a, b) {
+          return new Promise(function(resolve) {
+            setTimeout(function() {
+              resolve(a + b);
+            }, 10);
+          });
+        }
+
+        // Fill the queue with tasks
+        var task1 = pool.exec(delayedAdd, [1, 1]).then(function(result) { results.push(result); });
+        var task2 = pool.exec(delayedAdd, [2, 2]).then(function(result) { results.push(result); });
+        var task3 = pool.exec(delayedAdd, [3, 3]).then(function(result) { results.push(result); });
+        var task4 = pool.exec(delayedAdd, [4, 4]).then(function(result) { results.push(result); });
+
+        return Promise.all([task1, task2, task3, task4]).then(function() {
+          // FIFO should process tasks in order: 2, 4, 6, 8
+          assert.deepStrictEqual(results, [2, 4, 6, 8]);
+          return pool.terminate();
+        });
+      });
+
+      it('should process tasks in LIFO order with lifo strategy', function () {
+        var pool = createPool({maxWorkers: 1, queueStrategy: 'lifo'});
+        var results = [];
+
+        function delayedAdd(a, b) {
+          return new Promise(function(resolve) {
+            setTimeout(function() {
+              resolve(a + b);
+            }, 10);
+          });
+        }
+
+        // Fill the queue with tasks
+        var task1 = pool.exec(delayedAdd, [1, 1]).then(function(result) { results.push(result); });
+        var task2 = pool.exec(delayedAdd, [2, 2]).then(function(result) { results.push(result); });
+        var task3 = pool.exec(delayedAdd, [3, 3]).then(function(result) { results.push(result); });
+        var task4 = pool.exec(delayedAdd, [4, 4]).then(function(result) { results.push(result); });
+
+        return Promise.all([task1, task2, task3, task4]).then(function() {
+          // LIFO should process tasks in reverse order: 2, 8, 6, 4
+          assert.deepStrictEqual(results, [2, 8, 6, 4]);
+          return pool.terminate();
+        });
+      });
+
+      it('should accept custom queue strategy', function () {
+        // Create a priority queue that processes tasks with higher priority first
+        function PriorityQueue() {
+          this.tasks = [];
+        }
+
+        PriorityQueue.prototype.push = function(task) {
+          this.tasks.push(task);
+          // Sort by priority (higher priority first)
+          this.tasks.sort(function(a, b) {
+            return (b.priority || 0) - (a.priority || 0);
+          });
+        };
+
+        PriorityQueue.prototype.pop = function() {
+          return this.tasks.shift();
+        };
+
+        PriorityQueue.prototype.size = function() {
+          return this.tasks.length;
+        };
+
+        PriorityQueue.prototype.contains = function(task) {
+          return this.tasks.includes(task);
+        };
+
+        PriorityQueue.prototype.clear = function() {
+          this.tasks.length = 0;
+        };
+
+        var customQueue = new PriorityQueue();
+        var pool = createPool({queueStrategy: customQueue});
+
+        assert.strictEqual(pool.taskQueue, customQueue);
+
+        return pool.terminate();
+      });
+
+      it('should process tasks according to custom queue strategy behavior', function () {
+        // Create a reverse queue (LIFO-like but simpler to test)
+        function ReverseQueue() {
+          this.tasks = [];
+        }
+
+        ReverseQueue.prototype.push = function(task) {
+          this.tasks.unshift(task); // Insert at the beginning instead of the end
+        };
+
+        ReverseQueue.prototype.pop = function() {
+          return this.tasks.shift(); // Take from the beginning
+        };
+
+        ReverseQueue.prototype.size = function() {
+          return this.tasks.length;
+        };
+
+        ReverseQueue.prototype.contains = function(task) {
+          return this.tasks.includes(task);
+        };
+
+        ReverseQueue.prototype.clear = function() {
+          this.tasks.length = 0;
+        };
+
+        var customQueue = new ReverseQueue();
+        var pool = createPool({maxWorkers: 1, queueStrategy: customQueue});
+        var results = [];
+
+        function delayedAdd(a, b) {
+          return new Promise(function(resolve) {
+            setTimeout(function() {
+              resolve(a + b);
+            }, 10);
+          });
+        }
+
+        // Add tasks - the first task will start immediately, others will be queued
+        var task1 = pool.exec(delayedAdd, [1, 1]).then(function(result) { results.push(result); });
+        var task2 = pool.exec(delayedAdd, [2, 2]).then(function(result) { results.push(result); });
+        var task3 = pool.exec(delayedAdd, [3, 3]).then(function(result) { results.push(result); });
+        var task4 = pool.exec(delayedAdd, [4, 4]).then(function(result) { results.push(result); });
+
+        return Promise.all([task1, task2, task3, task4]).then(function() {
+          // With reverse queue (using unshift for push), execution order should be:
+          // task1 (2) - executed first as it started immediately
+          // task4 (8) - was the last added, so it's first in the reverse queue
+          // task3 (6) - second to last added
+          // task2 (4) - first added to queue, so last in reverse queue
+          assert.deepStrictEqual(results, [2, 8, 6, 4]);
+          return pool.terminate();
+        });
       });
     });
   });
@@ -1114,12 +1284,12 @@ describe('Pool', function () {
     var promise2 = pool.exec(test2);
 
     assert.strictEqual(pool.workers.length, 1);
-    assert.strictEqual(pool.tasks.length, 1);
+    assert.strictEqual(pool.taskQueue.size(), 1);
 
     return pool.terminate(false)
       .then(function() {
         assert.strictEqual(pool.workers.length, 0);
-        assert.strictEqual(pool.tasks.length, 0);
+        assert.strictEqual(pool.taskQueue.size(), 0);
 
         return Promise.all([
           promise1.then(function (result) {
@@ -1199,20 +1369,20 @@ describe('Pool', function () {
       return a + b;
     }
 
-    assert.strictEqual(pool.tasks.length, 0);
+    assert.strictEqual(pool.taskQueue.size(), 0);
     assert.strictEqual(pool.workers.length, 0);
 
     var task1 = pool.exec(add, [3, 4]);
     var task2 = pool.exec(add, [2, 3]);
 
-    assert.strictEqual(pool.tasks.length, 0);
+    assert.strictEqual(pool.taskQueue.size(), 0);
     assert.strictEqual(pool.workers.length, 2);
 
     var task3 = pool.exec(add, [5, 7]);
     var task4 = pool.exec(add, [1, 1]);
     var task5 = pool.exec(add, [6, 3]);
 
-    assert.strictEqual(pool.tasks.length, 3);
+    assert.strictEqual(pool.taskQueue.size(), 3);
     assert.strictEqual(pool.workers.length, 2);
 
     assert.throws(function () {pool.exec(add, [9, 4])}, Error);
@@ -1225,7 +1395,7 @@ describe('Pool', function () {
         task5
         ])
         .then(function () {
-          assert.strictEqual(pool.tasks.length, 0);
+          assert.strictEqual(pool.taskQueue.size(), 0);
           assert.strictEqual(pool.workers.length, 2);
 
           return pool.terminate();
@@ -1513,7 +1683,7 @@ describe('Pool', function () {
         .catch(function(err) {
           assert(err instanceof Promise.TimeoutError);
           var stats = pool.stats();
-          assert.strictEqual(stats.busyWorkers, 1);
+          assert(stats.busyWorkers === 1);
           assert.strictEqual(stats.totalWorkers, 1);
         }).always(function () {
           return pool.exec(add, [1, 2]).then(function () {

--- a/test/Queues.test.js
+++ b/test/Queues.test.js
@@ -1,0 +1,271 @@
+var assert = require('assert');
+var { FIFOQueue, LIFOQueue } = require('../src/queues');
+
+describe('Queues', function () {
+
+  describe('FIFOQueue', function() {
+    var queue;
+
+    beforeEach(function() {
+      queue = new FIFOQueue();
+    });
+
+    it('should create an empty queue', function() {
+      assert.strictEqual(queue.size(), 0);
+    });
+
+    it('should push tasks to the queue', function() {
+      var task1 = { id: 1 };
+      var task2 = { id: 2 };
+
+      queue.push(task1);
+      assert.strictEqual(queue.size(), 1);
+
+      queue.push(task2);
+      assert.strictEqual(queue.size(), 2);
+    });
+
+    it('should pop tasks in FIFO order', function() {
+      var task1 = { id: 1 };
+      var task2 = { id: 2 };
+      var task3 = { id: 3 };
+
+      queue.push(task1);
+      queue.push(task2);
+      queue.push(task3);
+
+      assert.strictEqual(queue.pop(), task1);
+      assert.strictEqual(queue.pop(), task2);
+      assert.strictEqual(queue.pop(), task3);
+      assert.strictEqual(queue.size(), 0);
+    });
+
+    it('should return undefined when popping from empty queue', function() {
+      assert.strictEqual(queue.pop(), undefined);
+    });
+
+    it('should correctly report size', function() {
+      assert.strictEqual(queue.size(), 0);
+
+      queue.push({ id: 1 });
+      assert.strictEqual(queue.size(), 1);
+
+      queue.push({ id: 2 });
+      assert.strictEqual(queue.size(), 2);
+
+      queue.pop();
+      assert.strictEqual(queue.size(), 1);
+
+      queue.pop();
+      assert.strictEqual(queue.size(), 0);
+    });
+
+    it('should check if queue contains a task', function() {
+      var task1 = { id: 1 };
+      var task2 = { id: 2 };
+      var task3 = { id: 3 };
+
+      assert.strictEqual(queue.contains(task1), false);
+
+      queue.push(task1);
+      queue.push(task2);
+
+      assert.strictEqual(queue.contains(task1), true);
+      assert.strictEqual(queue.contains(task2), true);
+      assert.strictEqual(queue.contains(task3), false);
+    });
+
+    it('should be iterable', function() {
+      var task1 = { id: 1 };
+      var task2 = { id: 2 };
+      var task3 = { id: 3 };
+
+      queue.push(task1);
+      queue.push(task2);
+      queue.push(task3);
+
+      var tasks = [];
+      for (var task of queue) {
+        tasks.push(task);
+      }
+
+      assert.deepStrictEqual(tasks, [task1, task2, task3]);
+    });
+
+    it('should clear all tasks', function() {
+      queue.push({ id: 1 });
+      queue.push({ id: 2 });
+      queue.push({ id: 3 });
+
+      assert.strictEqual(queue.size(), 3);
+
+      queue.clear();
+
+      assert.strictEqual(queue.size(), 0);
+      assert.strictEqual(queue.pop(), undefined);
+    });
+
+    it('should handle mixed operations correctly', function() {
+      var task1 = { id: 1 };
+      var task2 = { id: 2 };
+      var task3 = { id: 3 };
+
+      queue.push(task1);
+      queue.push(task2);
+      assert.strictEqual(queue.pop(), task1);
+
+      queue.push(task3);
+      assert.strictEqual(queue.pop(), task2);
+      assert.strictEqual(queue.pop(), task3);
+      assert.strictEqual(queue.size(), 0);
+    });
+  });
+
+  describe('LIFOQueue', function() {
+    var queue;
+
+    beforeEach(function() {
+      queue = new LIFOQueue();
+    });
+
+    it('should create an empty queue', function() {
+      assert.strictEqual(queue.size(), 0);
+    });
+
+    it('should push tasks to the queue', function() {
+      var task1 = { id: 1 };
+      var task2 = { id: 2 };
+
+      queue.push(task1);
+      assert.strictEqual(queue.size(), 1);
+
+      queue.push(task2);
+      assert.strictEqual(queue.size(), 2);
+    });
+
+    it('should pop tasks in LIFO order', function() {
+      var task1 = { id: 1 };
+      var task2 = { id: 2 };
+      var task3 = { id: 3 };
+
+      queue.push(task1);
+      queue.push(task2);
+      queue.push(task3);
+
+      assert.strictEqual(queue.pop(), task3);
+      assert.strictEqual(queue.pop(), task2);
+      assert.strictEqual(queue.pop(), task1);
+      assert.strictEqual(queue.size(), 0);
+    });
+
+    it('should return undefined when popping from empty queue', function() {
+      assert.strictEqual(queue.pop(), undefined);
+    });
+
+    it('should correctly report size', function() {
+      assert.strictEqual(queue.size(), 0);
+
+      queue.push({ id: 1 });
+      assert.strictEqual(queue.size(), 1);
+
+      queue.push({ id: 2 });
+      assert.strictEqual(queue.size(), 2);
+
+      queue.pop();
+      assert.strictEqual(queue.size(), 1);
+
+      queue.pop();
+      assert.strictEqual(queue.size(), 0);
+    });
+
+    it('should check if queue contains a task', function() {
+      var task1 = { id: 1 };
+      var task2 = { id: 2 };
+      var task3 = { id: 3 };
+
+      assert.strictEqual(queue.contains(task1), false);
+
+      queue.push(task1);
+      queue.push(task2);
+
+      assert.strictEqual(queue.contains(task1), true);
+      assert.strictEqual(queue.contains(task2), true);
+      assert.strictEqual(queue.contains(task3), false);
+    });
+
+    it('should be iterable', function() {
+      var task1 = { id: 1 };
+      var task2 = { id: 2 };
+      var task3 = { id: 3 };
+
+      queue.push(task1);
+      queue.push(task2);
+      queue.push(task3);
+
+      var tasks = [];
+      for (var task of queue) {
+        tasks.push(task);
+      }
+
+      assert.deepStrictEqual(tasks, [task1, task2, task3]);
+    });
+
+    it('should clear all tasks', function() {
+      queue.push({ id: 1 });
+      queue.push({ id: 2 });
+      queue.push({ id: 3 });
+
+      assert.strictEqual(queue.size(), 3);
+
+      queue.clear();
+
+      assert.strictEqual(queue.size(), 0);
+      assert.strictEqual(queue.pop(), undefined);
+    });
+
+    it('should handle mixed operations correctly', function() {
+      var task1 = { id: 1 };
+      var task2 = { id: 2 };
+      var task3 = { id: 3 };
+
+      queue.push(task1);
+      queue.push(task2);
+      assert.strictEqual(queue.pop(), task2);
+
+      queue.push(task3);
+      assert.strictEqual(queue.pop(), task3);
+      assert.strictEqual(queue.pop(), task1);
+      assert.strictEqual(queue.size(), 0);
+    });
+  });
+
+  describe('Queue comparison', function() {
+    it('should demonstrate FIFO vs LIFO behavior', function() {
+      var fifoQueue = new FIFOQueue();
+      var lifoQueue = new LIFOQueue();
+
+      var task1 = { id: 1 };
+      var task2 = { id: 2 };
+      var task3 = { id: 3 };
+
+      // Add same tasks to both queues
+      fifoQueue.push(task1);
+      fifoQueue.push(task2);
+      fifoQueue.push(task3);
+
+      lifoQueue.push(task1);
+      lifoQueue.push(task2);
+      lifoQueue.push(task3);
+
+      // FIFO should return tasks in order: task1, task2, task3
+      assert.strictEqual(fifoQueue.pop(), task1);
+      assert.strictEqual(fifoQueue.pop(), task2);
+      assert.strictEqual(fifoQueue.pop(), task3);
+
+      // LIFO should return tasks in reverse order: task3, task2, task1
+      assert.strictEqual(lifoQueue.pop(), task3);
+      assert.strictEqual(lifoQueue.pop(), task2);
+      assert.strictEqual(lifoQueue.pop(), task1);
+    });
+  });
+});


### PR DESCRIPTION
This PR implements the feature requested in #517 .

### Changes
- Introduced `TaskQueue` interface and refactored pool internals.
- Added built-in `FifoQueue` (default) and `LifoQueue`.
- `queueStrategy` option in `workerpool.pool()` accepts:
  - 'fifo' | 'lifo' | CustomQueueClass.
- Added unit tests for all strategies.

> NOTE: All unit tests is created by AI.

Closes #517 .