### PR TITLE
feat: add TerminateError

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const {platform, isMainThread, cpus} = require('./environment');
+const {TerminateError} = require('./WorkerHandler');
 
 /** @typedef {import("./Pool")} Pool */
 /** @typedef {import("./types.js").WorkerPoolOptions} WorkerPoolOptions */
@@ -58,3 +59,4 @@ exports.Transfer = require('./transfer');
 exports.platform = platform;
 exports.isMainThread = isMainThread;
 exports.cpus = cpus;
+exports.TerminateError = TerminateError;


### PR DESCRIPTION
Solves some of #519

This creates a new TerminateError type, which is used whenever propagating a promise rejection through to an `exec` call, so that the caller can differentiate fatal errors in the worker thread from runtime/application errors. 