### PR TITLE
Use availableParallelism, not cpus().length when determining max workers

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -24,7 +24,8 @@ module.exports.isMainThread = module.exports.platform === 'node'
   : typeof Window !== 'undefined';
 
 // determines the number of cpus available
+var os = require('os')
 module.exports.cpus = module.exports.platform === 'browser'
   ? self.navigator.hardwareConcurrency
-  : require('os').cpus().length;
+  : (((typeof os?.availableParallelism === "function") && os.availableParallelism()) || os.cpus().length);
 

--- a/src/environment.js
+++ b/src/environment.js
@@ -24,8 +24,7 @@ module.exports.isMainThread = module.exports.platform === 'node'
   : typeof Window !== 'undefined';
 
 // determines the number of cpus available
-var os = require('os')
 module.exports.cpus = module.exports.platform === 'browser'
   ? self.navigator.hardwareConcurrency
-  : (((typeof os?.availableParallelism === "function") && os.availableParallelism()) || os.cpus().length);
+  : require('os').availableParallelism();
 

--- a/test/Pool.test.js
+++ b/test/Pool.test.js
@@ -885,11 +885,11 @@ describe('Pool', function () {
       });
     });
 
-    it('should take number of cpus minus one as default maxWorkers', function () {
+    it('should take the available parallelism minus one as default maxWorkers', function () {
       var pool = createPool();
 
-      var cpus = require('os').cpus();
-      assert.strictEqual(pool.maxWorkers, cpus.length - 1);
+      var parallelism = require('os').availableParallelism();
+      assert.strictEqual(pool.maxWorkers, parallelism - 1);
 
       return pool.terminate();
     });
@@ -908,19 +908,19 @@ describe('Pool', function () {
       }, TypeError);
     });
 
-    it('should create number of cpus minus one when minWorkers set to \'max\'', function () {
+    it('should create available parallelism minus one when minWorkers set to \'max\'', function () {
       var pool = createPool({minWorkers:'max'});
 
-      var cpus = require('os').cpus();
-      assert.strictEqual(pool.workers.length, cpus.length - 1);
+      var parallelism = require('os').availableParallelism();
+      assert.strictEqual(pool.workers.length, parallelism - 1);
 
       return pool.terminate();
     });
 
     it('should increase maxWorkers to match minWorkers', function () {
-      var cpus = require('os').cpus();
-      var count = cpus.length + 2;
-      var tasksCount = cpus.length * 2;
+      var parallelism = require('os').availableParallelism();
+      var count = parallelism + 2;
+      var tasksCount = parallelism * 2;
       var pool = createPool({minWorkers: count});
 
       var tasks = []


### PR DESCRIPTION
Resolves #568

The `os.cpus()` documentation explicitly recommends against using that function for determining the resources available to your process. This is, among other things, because it is not container-aware. Instead, we use `availableParallelism` when running outside the browser, which is the recommended alternative.